### PR TITLE
add set to Fp6T and Fp2T

### DIFF
--- a/include/mcl/fp_tower.hpp
+++ b/include/mcl/fp_tower.hpp
@@ -119,6 +119,11 @@ public:
 		a.clear();
 		b.clear();
 	}
+	void set(const Fp &a_, const Fp &b_)
+	{
+		a = a_;
+		b = b_;
+	}
 	static void add(Fp2T& z, const Fp2T& x, const Fp2T& y) { Fp::op_.fp2_add(z.a.v_, x.a.v_, y.a.v_); }
 	static void sub(Fp2T& z, const Fp2T& x, const Fp2T& y) { Fp::op_.fp2_sub(z.a.v_, x.a.v_, y.a.v_); }
 	static void addPre(Fp2T& z, const Fp2T& x, const Fp2T& y) { Fp::addPre(z.a, x.a, y.a); Fp::addPre(z.b, x.b, y.b); }
@@ -575,6 +580,12 @@ struct Fp6T : public fp::Operator<Fp6T<Fp> > {
 	const Fp* getFp0() const { return a.getFp0(); }
 	Fp2* getFp2() { return &a; }
 	const Fp2* getFp2() const { return &a; }
+	void set(const Fp2 &a_, const Fp2 &b_, const Fp2 &c_)
+	{
+		a = a_;
+		b = b_;
+		c = c_;
+	}
 	bool isZero() const
 	{
 		return a.isZero() && b.isZero() && c.isZero();


### PR DESCRIPTION
Fp12T::set doesn't compile without Fp6T::set and having Fp2T::set is nice as it gives uniform interface for all classes.