### PR TITLE
drop _dy suffix from names of shared libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ ifeq ($(MCL_USE_XBYAK),0)
 endif
 ##################################################################
 MCL_LIB=$(LIB_DIR)/libmcl.a
-MCL_SLIB=$(LIB_DIR)/libmcl_dy.$(LIB_SUF)
+MCL_SLIB=$(LIB_DIR)/libmcl.$(LIB_SUF)
 BN256_LIB=$(LIB_DIR)/libbn256.a
-BN256_SLIB=$(LIB_DIR)/libbn256_dy.$(LIB_SUF)
+BN256_SLIB=$(LIB_DIR)/libbn256.$(LIB_SUF)
 all: $(MCL_LIB) $(MCL_SLIB) $(BN256_LIB) $(BN256_SLIB)
 
 #LLVM_VER=-3.8


### PR DESCRIPTION
I'm not sure why names of static and shared libraries are different, but certain build systems (Haskell's one in particular) just take the library name as a dependency and then use static or dynamic linking in appropriate situations. As it stands, they get confused, because they can't find the dynamic version and manual symlinking is needed to work around that.