### PR TITLE
Do not mark EcT coordinates mutable

### DIFF
--- a/include/mcl/bn.hpp
+++ b/include/mcl/bn.hpp
@@ -1172,8 +1172,10 @@ struct BNT {
 #endif
 		exp_d1(y, y);
 	}
-	static void millerLoop(Fp12& f, const G1& P, const G2& Q)
+	static void millerLoop(Fp12& f, const G1& P_, const G2& Q_)
 	{
+		G1 P(P_);
+		G2 Q(Q_);
 		P.normalize();
 		Q.normalize();
 		G2 T = Q;
@@ -1234,8 +1236,9 @@ struct BNT {
 	/*
 		allocate param.precomputedQcoeffSize elements of Fp6 for Qcoeff
 	*/
-	static void precomputeG2(Fp6 *Qcoeff, const G2& Q)
+	static void precomputeG2(Fp6 *Qcoeff, const G2& Q_)
 	{
+		G2 Q(Q_);
 		size_t idx = 0;
 		Q.normalize();
 		G2 T = Q;
@@ -1271,8 +1274,9 @@ struct BNT {
 	{
 		precomputedMillerLoop(f, P, Qcoeff.data());
 	}
-	static void precomputedMillerLoop(Fp12& f, const G1& P, const Fp6* Qcoeff)
+	static void precomputedMillerLoop(Fp12& f, const G1& P_, const Fp6* Qcoeff)
 	{
+		G1 P(P_);
 		P.normalize();
 		size_t idx = 0;
 		Fp6 d, e;
@@ -1312,8 +1316,9 @@ struct BNT {
 	{
 		precomputedMillerLoop2(f, P1, Q1coeff.data(), P2, Q2coeff.data());
 	}
-	static void precomputedMillerLoop2(Fp12& f, const G1& P1, const Fp6* Q1coeff, const G1& P2, const Fp6* Q2coeff)
+	static void precomputedMillerLoop2(Fp12& f, const G1& P1_, const Fp6* Q1coeff, const G1& P2_, const Fp6* Q2coeff)
 	{
+		G1 P1(P1_), P2(P2_);
 		P1.normalize();
 		P2.normalize();
 		size_t idx = 0;

--- a/include/mcl/ec.hpp
+++ b/include/mcl/ec.hpp
@@ -48,7 +48,7 @@ public:
 	Fp x, y;
 	bool inf_;
 #else
-	mutable Fp x, y, z;
+	Fp x, y, z;
 	static int mode_;
 #endif
 	static Fp a_;
@@ -78,7 +78,7 @@ public:
 	}
 #ifndef MCL_EC_USE_AFFINE
 private:
-	void normalizeJacobi() const
+	void normalizeJacobi()
 	{
 		assert(!z.isZero());
 		Fp rz2;
@@ -89,7 +89,7 @@ private:
 		y *= z;
 		z = 1;
 	}
-	void normalizeProj() const
+	void normalizeProj()
 	{
 		assert(!z.isZero());
 		Fp::inv(z, z);
@@ -141,7 +141,7 @@ private:
 	}
 public:
 #endif
-	void normalize() const
+	void normalize()
 	{
 #ifndef MCL_EC_USE_AFFINE
 		if (isNormalized()) return;
@@ -652,7 +652,7 @@ public:
 		<x>   ; for even y
 		<x>|1 ; for odd y ; |1 means set MSB of x
 	*/
-	void getStr(std::string& str, int ioMode = 10) const
+	void getStr(std::string& str, int ioMode = 10)
 	{
 		normalize();
 		if (ioMode & IoTight) {
@@ -686,7 +686,7 @@ public:
 			str += y.getStr(ioMode);
 		}
 	}
-	std::string getStr(int ioMode = 10) const
+	std::string getStr(int ioMode = 10)
 	{
 		std::string str;
 		getStr(str, ioMode);
@@ -695,7 +695,7 @@ public:
 	friend inline std::ostream& operator<<(std::ostream& os, const EcT& self)
 	{
 		int ioMode = fp::detectIoMode(Fp::BaseFp::getIoMode(), os);
-		return os << self.getStr(ioMode);
+		return os << EcT(self).getStr(ioMode);
 	}
 	friend inline std::istream& operator>>(std::istream& is, EcT& self)
 	{

--- a/include/mcl/util.hpp
+++ b/include/mcl/util.hpp
@@ -196,9 +196,9 @@ void getRandVal(T *out, RG& rg, const T *in, size_t bitSize)
 	@note &out != x and out = the unit element of G
 */
 template<class G, class T>
-void powGeneric(G& out, const G& x, const T *y, size_t n, void mul(G&, const G&, const G&) , void sqr(G&, const G&), bool constTime = false)
+void powGeneric(G& out, const G& x_, const T *y, size_t n, void mul(G&, const G&, const G&) , void sqr(G&, const G&), bool constTime = false)
 {
-	assert(&out != &x);
+	assert(&out != &x_);
 	while (n > 0) {
 		if (y[n - 1]) break;
 		n--;
@@ -207,22 +207,23 @@ void powGeneric(G& out, const G& x, const T *y, size_t n, void mul(G&, const G&,
 	if (n == 1) {
 		switch (y[0]) {
 		case 1:
-			out = x;
+			out = x_;
 			return;
 		case 2:
-			sqr(out, x);
+			sqr(out, x_);
 			return;
 		case 3:
-			sqr(out, x);
-			mul(out, out, x);
+			sqr(out, x_);
+			mul(out, out, x_);
 			return;
 		case 4:
-			sqr(out, x);
+			sqr(out, x_);
 			sqr(out, out);
 			return;
 		}
 	}
 	G tbl[4]; // tbl = { discard, x, x^2, x^3 }
+	G x(x_);
 	x.normalize();
 	tbl[0] = x;
 	tbl[1] = x;

--- a/src/bn256.cpp
+++ b/src/bn256.cpp
@@ -221,7 +221,7 @@ int BN256_G1_getStr(char *buf, int maxBufSize, const BN256_G1 *x)
 	try
 {
 	std::string str;
-	cast(x)->getStr(str);
+	G1(*cast(x)).getStr(str);
 	if ((int)str.size() < maxBufSize) {
 		memcpy(buf, str.c_str(), str.size() + 1);
 		return 0;
@@ -307,7 +307,7 @@ int BN256_G2_getStr(char *buf, int maxBufSize, const BN256_G2 *x)
 	try
 {
 	std::string str;
-	cast(x)->getStr(str);
+	G2(*cast(x)).getStr(str);
 	if ((int)str.size() < maxBufSize) {
 		memcpy(buf, str.c_str(), str.size() + 1);
 		return 0;


### PR DESCRIPTION
Current situation may result in a silent corruption in multi-threaded environment. If two threads hold a (seemingly) const reference to a point and e.g. the first thread calls arithmetic operation where the point is one of the operands whereas the second thread calls normalize on the point and these calls are interleaved, the first thread might produce invalid result.