### PR TITLE
Fix build failed on arm 32bit linux

### DIFF
--- a/include/mcl/ec.hpp
+++ b/include/mcl/ec.hpp
@@ -594,7 +594,7 @@ public:
 #else
 		uint32_t ua[2] = { uint32_t(u), uint32_t(u >> 32) };
 		size_t un = ua[1] ? 2 : 1;
-		mulArray(z, ua, un, y < 0);
+		mulArray(z, x, ua, un, y < 0);
 #endif
 	}
 	static inline void mul(EcT& z, const EcT& x, const mpz_class& y)


### PR DESCRIPTION
I found this problem on arm 32bit (Raspberry Pi3 / arm 32bit version Raspbian)

Error message:
include/mcl/ec.hpp:597:11: error: no matching function for call to ‘mcl::EcT<mcl::Fp2T<mcl::FpT<mcl::bn256::local::FpTag, 256u> > >::mulArray(mcl::EcT<mcl::Fp2T<mcl::FpT<mcl::bn256::local::FpTag, 256u> > >&, uint32_t [2], size_t&, bool)’
   mulArray(z, ua, un, y < 0);