### PR TITLE
fix: fix make failed on except for linux

### DIFF
--- a/include/mcl/array.hpp
+++ b/include/mcl/array.hpp
@@ -6,7 +6,13 @@
 	@license modified new BSD license
 	http://opensource.org/licenses/BSD-3-Clause
 */
+
+#ifdef __linux
 #include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
+
 #include <stddef.h>
 
 namespace mcl {


### PR DESCRIPTION
Fixed an issue where `make` commands fail on non-linux such as MacOS.
