### PR TITLE
common.mk: do not assume openssl install path for Darwin

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -14,8 +14,6 @@ ifeq ($(UNAME_S),Darwin)
   OS=mac
   ARCH=x86_64
   LIB_SUF=dylib
-  CFLAGS+=-I/usr/local/opt/openssl/include
-  LDFLAGS+=-L/usr/local/opt/openssl/lib
 else
   LIB_SUF=so
 endif


### PR DESCRIPTION
Non-root installation of homebrew does not install openssl under /usr/local.
Let user handle the LDFLAG and include path on their own.