### PR TITLE
shared libraries should be linked to their dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ include_directories(
 
 add_library(mcl STATIC ${SRCS})
 add_library(mcl_dy SHARED ${SRCS})
+target_link_libraries(mcl_dy ${LIBS})
 set_target_properties(mcl_dy PROPERTIES OUTPUT_NAME mcl)
 if(NOT USE_OLD_SHARED_NAME)
 	set_target_properties(mcl_dy PROPERTIES OUTPUT_NAME mcl)


### PR DESCRIPTION
Otherwise, the build fails when another project wants to link only to mcl (but not directly to ssl/crypto/gmp/gmpxx because it doesn't directly use them).
