### PR TITLE
Fix Fp2::init() call in samples

### DIFF
--- a/sample/rawbench.cpp
+++ b/sample/rawbench.cpp
@@ -26,7 +26,7 @@ void mul9(const mcl::fp::Op& op, Unit *y, const Unit *x, const Unit *p)
 void benchRaw(const char *p, mcl::fp::Mode mode)
 {
 	Fp::init(p, mode);
-	Fp2::init(1);
+	Fp2::init();
 	const size_t maxN = sizeof(Fp) / sizeof(Unit);
 	const mcl::fp::Op& op = Fp::getOp();
 	cybozu::XorShift rg;


### PR DESCRIPTION
The change of Fp2::init() in ad282ed is causing `make sample` to result in the following error:

```
c++ -isystem/opt/brew/include  -I/usr/local/opt/openssl/include -I/usr/local/opt/gmp/include -g3 -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith -m64 -I include -I test -fomit-frame-pointer -DNDEBUG -O3  -fPIC -DMCL_USE_LLVM=1 -c sample/rawbench.cpp -o obj/rawbench.o -MMD -MP -MF obj/rawbench.d
sample/rawbench.cpp:29:12: error: too many arguments to function call, expected 0, have 1
        Fp2::init(1);
        ~~~~~~~~~ ^
include/mcl/fp_tower.hpp:384:2: note: 'init' declared here
        static void init()
        ^
1 error generated.
make: *** [obj/rawbench.o] Error 1
```

This patch fixes this issue.