### PR TITLE
Fix she-api documents

### DIFF
--- a/misc/she/she-api-ja.md
+++ b/misc/she/she-api-ja.md
@@ -250,7 +250,7 @@ PrecomputedPublicKeyはPublicKeyの高速版
 * `CT she.sub(CT x, CT y)`(JS)
     * 暗号文xから暗号文yを引いてzにセットする(またはその値を返す)
 * `void CT::neg(CT& y, const CT& x)`(C++)
-* `void she.neg(CT x)`(JS)
+* `CT she.neg(CT x)`(JS)
     * 暗号文xの符号反転をyにセットする(またはその値を返す)
 * `void CT::mul(CT& z, const CT& x, int y)`(C++)
 * `CT she.mulInt(CT x, int y)`(JS)

--- a/misc/she/she-api.md
+++ b/misc/she/she-api.md
@@ -255,7 +255,7 @@ PK means PublicKey or PrecomputedPublicKey
 * `CT she.sub(CT x, CT y)`(JS)
     * subtract `x` and `y` and set the value to `z`(or return the value)
 * `void CT::neg(CT& y, const CT& x)`(C++)
-* `void she.neg(CT x)`(JS)
+* `CT she.neg(CT x)`(JS)
     * negate `x` and set the value to `y`(or return the value)
 * `void CT::mul(CT& z, const CT& x, int y)`(C++)
 * `CT she.mulInt(CT x, int y)`(JS)


### PR DESCRIPTION
I found a typo about type of following the method in she-api.md and she-api-ja.md.

`void she.neg(CT x)`(JS)
→
`CT she.neg(CT x)`(JS)

https://github.com/herumi/she-wasm/blob/c7fac83ee9057c1b081b6286c252caa971fbbe9b/she.js#L572-L593