### PR TITLE
fix a CALL16 reloc error when cross-compiling with mips toolchain.

### DIFF
--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -671,7 +671,7 @@ struct Code : public mcl::Generator {
 		Operand y(Int, unit);
 		std::string name = "mulPv" + cybozu::itoa(bit) + "x" + cybozu::itoa(unit);
 		mulPvM[bit] = Function(name, z, px, y);
-		// workaround at https://github.com/herumi/mcl/pull/82
+              // workaround at https://github.com/herumi/mcl/pull/82
 //		mulPvM[bit].setPrivate();
 		verifyAndSetPrivate(mulPvM[bit]);
 		beginFunc(mulPvM[bit]);


### PR DESCRIPTION
This PR is in support of herumi/bls-eth-go-binary#22

When attempting to cross compile for MIPS I get the following error in the linking step of the sample.go program in the [herumi/bls-eth-go-binary](https://github.com/herumi/bls-eth-go-binary) repo.  

```
# github.com/herumi/bls-eth-go-binary/bls
/root/source/staging_dir/toolchain-mipsel_24kc_gcc-7.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/7.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld: bls/lib/linux/mips/libbls384_256.a(base32.o): CALL16 reloc at 0x253f0 not against global symbol
bls/lib/linux/mips/libbls384_256.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
```

The go build command looks like this:
```
env \
STAGING_DIR="/root/source/staging_dir" \
CGO_LDFLAGS="-L/root/work/bls-eth-go-binary-jrhea/bls/lib/linux/mips" \
CGO_LDLIBS="-lbls384_256" \
CGO_CXXFLAGS="-std=c++03 -O3 -fPIC -DNDEBUG -DMCL_DONT_USE_OPENSSL -DMCL_LLVM_BMI2=0 -DMCL_USE_LLVM=1 -DMCL_USE_VINT -DMCL_SIZEOF_UNIT=4 -DMCL_VINT_FIXED_BUFFER -DMCL_MAX_BIT_SIZE=384 -DCYBOZU_DONT_USE_EXCEPTION -DCYBOZU_DONT_USE_STRING -D_FORTIFY_SOURCE=0 -DBLS_ETH -DBLS_SWAP_G  -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -Wformat -Werror=format-security -fstack-protector -Wl,-z,now -Wl,-z,relro " \
GOOS=linux \
GOARCH=mipsle \
GOMIPS=softfloat \
CGO_ENABLED=1 \
CXX_FOR_TARGET="/root/source/staging_dir/toolchain-mipsel_24kc_gcc-7.3.0_musl/bin/mipsel-openwrt-linux-g++" \
CC_FOR_TARGET="/root/source/staging_dir/toolchain-mipsel_24kc_gcc-7.3.0_musl/bin/mipsel-openwrt-linux-gcc" \
go build examples/sample.go
```

Based on the error I searched the symbol output and saw this:

```
root@0fe82bf96b16:~/work/bls-eth-go-binary# nm obj/base32.o 
00025208 t $mulPv288x32
0002f1d0 t $mulPv320x32
00039f80 t $mulPv352x32
00048bbc t $mulPv384x32
000586f4 t $mulPv416x32
0006d9a4 t $mulPv448x32
00082d80 t $mulPv480x32
000a10d4 t $mulPv512x32
000c1608 t $mulPv544x32
```

The `t` told me the symbol was local to the library.  It's possible that differences in compilers could cause different behaviors, but I couldn't find anything concrete so I opted to make the symbol not private.  That seemed to fix the issue.  

Any alternative suggestions would be appreciated as well.  Thanks.
