### PR TITLE
Add support for building on OpenBSD

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -23,6 +23,13 @@ ifeq ($(UNAME_S),Darwin)
 else
   LIB_SUF=so
 endif
+ifeq ($(UNAME_S),OpenBSD)
+  OS=openbsd
+  CXX=clang++
+  CFLAGS+=-I/usr/local/include
+  LDFLAGS+=-L/usr/local/lib
+endif
+
 ARCH?=$(shell uname -m)
 ifneq ($(findstring $(ARCH),x86_64/amd64),)
   CPU=x86-64
@@ -51,7 +58,7 @@ ifeq ($(ARCH),aarch64)
   CPU=aarch64
   BIT=64
 endif
-ifeq ($(findstring $(OS),mac/mingw64),)
+ifeq ($(findstring $(OS),mac/mingw64/openbsd),)
   LDFLAGS+=-lrt
 endif
 

--- a/common.mk
+++ b/common.mk
@@ -73,10 +73,11 @@ ifeq ($(DEBUG),1)
     LDFLAGS+=-fsanitize=address
   endif
 else
-  CFLAGS_OPT+=-fomit-frame-pointer -DNDEBUG -fno-stack-protector
+
   ifeq ($(CXX),clang++)
     CFLAGS_OPT+=-O3
   else
+    CFLAGS_OPT+=-fomit-frame-pointer -DNDEBUG -fno-stack-protector
     ifeq ($(shell expr $(GCC_VER) \> 4.6.0),1)
       CFLAGS_OPT+=-Ofast
     else


### PR DESCRIPTION

This PR allows mcl to be built on OpenBSD using the Makefile. Modern releases of OpenBSD include both clang and gcc in the base system. Building mcl on the included version of gcc however is problematic since it is ancient (v4.2.1) and results in a cascade of missing instruction (mulxq) errors. The changes in this PR configure the Makefile to use the clang compiler instead on OpenBSD. 

Build log: https://pastebin.com/raw/48zfguVL

Also included is a patch that moves some build flags that are specific to gcc to an underlying conditional block to prevent them from being used for clang. 

Test results on my OpenBSD-current system:
```
alexander@proofofbsd ~/Desktop/alexander-mcl $ gmake bin/bn_c384_256_test.exe && bin/bn_c384_256_test.exe
clang++ -I/usr/local/include -g3 -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith -m64 -I include -I test -O3  -DMCL_DONT_USE_OPENSSL -fPIC -DMCL_USE_LLVM=1 -c test/bn_c384_256_test.cpp -o obj/bn_c384_256_test.o -MMD -MP -MF obj/bn_c384_256_test.d
clang++ obj/bn_c384_256_test.o -o bin/bn_c384_256_test.exe lib/libmclbn384_256.a lib/libmcl.a -L/usr/local/lib -lgmp -lgmpxx  -m64 
ctest:module=init
.. omitted ..
ctest:name=bn_c384_256_test, module=29, total=727, ok=727, ng=0, exception=0
```
```
alexander@proofofbsd ~/Desktop/alexander-mcl $ gmake bin/bls12_test.exe && bin/bls12_test.exe             
clang++ -I/usr/local/include -g3 -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith -m64 -I include -I test -O3  -DMCL_DONT_USE_OPENSSL -fPIC -DMCL_USE_LLVM=1 -c test/bls12_test.cpp -o obj/bls12_test.o -MMD -MP -MF obj/bls12_test.d
clang++ obj/bls12_test.o -o bin/bls12_test.exe lib/libmcl.a -L/usr/local/lib -lgmp -lgmpxx  -m64 
JIT 0
.. omitted ..
ctest:name=bls12_test, module=9, total=3727, ok=3727, ng=0, exception=0
```
If you are interested in this PR, I'd be happy to improve upon it - such as adding support to the CMake build system. 
