### PR TITLE
Hash to curve 09 h.10.1 i.1

### DIFF
--- a/test/mapto_wb19_test.cpp
+++ b/test/mapto_wb19_test.cpp
@@ -293,6 +293,97 @@ void testHashToFp2v7(const T& mapto)
 		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
 		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
 	}
+	// Test coming from https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-09#appendix-I.1
+	{
+		char msg[] = "";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "f659819a6473c1835b25ea59e3d38914c98b374f0970b7e4c92181df928fca88";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[32];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "abc";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "1c38f7c211ef233367b2420d04798fa4698080a8901021a795a1151775fe4da7";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[32];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "abcdef0123456789";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "8f7e7b66791f0da0dbb5ec7c22ec637f79758c0a48170bfb7c4611bd304ece89";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[32];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "72d5aa5ec810370d1f0013c0df2f1d65699494ee2a39f72e1716b1b964e1c642";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[32];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "8bcffd1a3cae24cf9cd7ab85628fd111bb17e3739d3b53f89580d217aa79526f1708354a76a402d3569d6a9d19ef3de4d0b991e4f54b9f20dcde9b95a66824cbdf6c1a963a1913d43fd7ac443a02fc5d9d8d77e2071b86ab114a9f34150954a7531da568a1ea8c760861c0cde2005afc2c114042ee7b5848f5303f0611cf297f";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[128];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "abc";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "fe994ec51bdaa821598047b3121c149b364b178606d5e72bfbb713933acc29c186f316baecf7ea22212f2496ef3f785a27e84a40d8b299cec56032763eceeff4c61bd1fe65ed81decafff4a31d0198619c0aa0c6c51fca15520789925e813dcfd318b542f8799441271f4db9ee3b8092a7a2e8d5b75b73e28fb1ab6b4573c192";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[128];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "abcdef0123456789";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "c9ec7941811b1e19ce98e21db28d22259354d4d0643e301175e2f474e030d32694e9dd5520dde93f3600d8edad94e5c364903088a7228cc9eff685d7eaac50d5a5a8229d083b51de4ccc3733917f4b9535a819b445814890b7029b5de805bf62b33a4dc7e24acdf2c924e9fe50d55a6b832c8c84c7f82474b34e48c6d43867be";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[128];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "48e256ddba722053ba462b2b93351fc966026e6d6db493189798181c5f3feea377b5a6f1d8368d7453faef715f9aecb078cd402cbd548c0e179c4ed1e4c7e5b048e0a39d31817b5b24f50db58bb3720fe96ba53db947842120a068816ac05c159bb5266c63658b4f000cbf87b1209a225def8ef1dca917bcda79a1e42acd8069";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[128];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
+	{
+		char msg[] = "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+		char dst[] = "QUUX-V01-CS02-with-expander";
+		char expect[] = "396962db47f749ec3b5042ce2452b619607f27fd3939ece2746a7614fb83a1d097f554df3927b084e55de92c7871430d6b95c2a13896d8a33bc48587b1f66d21b128a1a8240d5b0c26dfe795a1a842a0807bb148b77c2ef82ed4b6c9f7fcb732e7f94466c8b51e52bf378fba044a31f5cb44583a892f5969dcd73b3fa128816e";
+		size_t msgSize = strlen(msg);
+		size_t dstSize = strlen(dst);
+		uint8_t md[128];
+		mcl::fp::expand_message_xmd(md, sizeof(md), msg, msgSize, dst, dstSize);
+		CYBOZU_TEST_EQUAL(toHexStr(md, sizeof(md)), expect);
+	}
 	{
 		const struct {
 			const char *msg;

--- a/test/mapto_wb19_test.cpp
+++ b/test/mapto_wb19_test.cpp
@@ -362,6 +362,55 @@ void testHashToFp2v7(const T& mapto)
 					"0x12424ac32561493f3fe3c260708a12b7c620e7be00099a974e259ddc7d1f6395c3c811cdd19f1e8dbf3e9ecfdcbab8d6",
 				}
 			},
+			// https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-09.html#name-bls12381g2_xmdsha-256_sswu_
+			{
+				"abc", // msg
+        "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_",
+				{ // P.x
+					"0x02c2d18e033b960562aae3cab37a27ce00d80ccd5ba4b7fe0e7a210245129dbec7780ccc7954725f4168aff2787776e6",
+					"0x139cddbccdc5e91b9623efd38c49f81a6f83f175e80b06fc374de9eb4b41dfe4ca3a230ed250fbe3a2acf73a41177fd8",
+				},
+				{ // P.y
+					"0x1787327b68159716a37440985269cf584bcb1e621d3a7202be6ea05c4cfe244aeb197642555a0645fb87bf7466b2ba48",
+					"0x00aa65dae3c8d732d10ecd2c50f8a1baf3001578f71c694e03866e9f3d49ac1e1ce70dd94a733534f106d4cec0eddd16",
+				}
+			},
+			{
+				"abcdef0123456789", // msg
+        "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_",
+				{ // P.x
+					"0x121982811d2491fde9ba7ed31ef9ca474f0e1501297f68c298e9f4c0028add35aea8bb83d53c08cfc007c1e005723cd0",
+					"0x190d119345b94fbd15497bcba94ecf7db2cbfd1e1fe7da034d26cbba169fb3968288b3fafb265f9ebd380512a71c3f2c",
+				},
+				{ // P.y
+					"0x05571a0f8d3c08d094576981f4a3b8eda0a8e771fcdcc8ecceaf1356a6acf17574518acb506e435b639353c2e14827c8",
+					"0x0bb5e7572275c567462d91807de765611490205a941a5a6af3b1691bfe596c31225d3aabdf15faff860cb4ef17c7c3be",
+				}
+			},
+			{
+				"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq", // msg
+        "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_",
+				{ // P.x
+					"0x19a84dd7248a1066f737cc34502ee5555bd3c19f2ecdb3c7d9e24dc65d4e25e50d83f0f77105e955d78f4762d33c17da",
+					"0x0934aba516a52d8ae479939a91998299c76d39cc0c035cd18813bec433f587e2d7a4fef038260eef0cef4d02aae3eb91",
+				},
+				{ // P.y
+					"0x14f81cd421617428bc3b9fe25afbb751d934a00493524bc4e065635b0555084dd54679df1536101b2c979c0152d09192",
+					"0x09bcccfa036b4847c9950780733633f13619994394c23ff0b32fa6b795844f4a0673e20282d07bc69641cee04f5e5662",
+				}
+			},
+			{
+				"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // msg
+        "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_",
+				{ // P.x
+					"0x01a6ba2f9a11fa5598b2d8ace0fbe0a0eacb65deceb476fbbcb64fd24557c2f4b18ecfc5663e54ae16a84f5ab7f62534",
+					"0x11fca2ff525572795a801eed17eb12785887c7b63fb77a42be46ce4a34131d71f7a73e95fee3f812aea3de78b4d01569",
+				},
+				{ // P.y
+					"0x0b6798718c8aed24bc19cb27f866f1c9effcdbf92397ad6448b5c9db90d2b9da6cbabf48adc1adf59a1a28344e79d57e",
+					"0x03a47f8e6d1763ba0cad63d6114c0accbef65707825a511b251a660a9b3994249ae4e63fac38b23da0c398689ee2ab52",
+				}
+			},
 		};
 		for (size_t i = 0; i < CYBOZU_NUM_OF_ARRAY(tbl); i++) {
 			const char *msg = tbl[i].msg;


### PR DESCRIPTION
This PR proposes to add:

- the test vectors of `expand_message_xmd(SHA-256)` of the [RFC§I.1](https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-09#appendix-I.1);
- the test vectors of `BLS12381G2_XMD:SHA-256_SSWU_RO_` of the [RFC§H.10.1](https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-09#appendix-H.10.1).

All these tests are OK.