### PR TITLE
Added Fr.setLittleEndianMod and G1.isValidOrder() to JNI

### DIFF
--- a/ffi/java/MclTest.java
+++ b/ffi/java/MclTest.java
@@ -51,6 +51,8 @@ public class MclTest {
 				Fr t = new Fr();
 				t.deserialize(b);
 				assertBool("serialize", x.equals(t));
+				t.setLittleEndianMod(b);
+				assertBool("setLittleEndianMod", x.equals(t));
 			}
 			G1 P = new G1();
 			System.out.println("P=" + P);

--- a/ffi/java/com/herumi/mcl/Fr.java
+++ b/ffi/java/com/herumi/mcl/Fr.java
@@ -96,6 +96,10 @@ public class Fr {
     MclJNI.Fr_deserialize(swigCPtr, this, cbuf);
   }
 
+  public void setLittleEndianMod(byte[] cbuf) {
+    MclJNI.Fr_setLittleEndianMod(swigCPtr, this, cbuf);
+  }
+
   public byte[] serialize() { return MclJNI.Fr_serialize(swigCPtr, this); }
 
 }

--- a/ffi/java/com/herumi/mcl/G1.java
+++ b/ffi/java/com/herumi/mcl/G1.java
@@ -56,6 +56,10 @@ public class G1 {
     return MclJNI.G1_isZero(swigCPtr, this);
   }
 
+  public boolean isValidOrder() {
+    return MclJNI.G1_isValidOrder(swigCPtr, this);
+  }
+
   public void set(Fp x, Fp y) {
     MclJNI.G1_set(swigCPtr, this, Fp.getCPtr(x), x, Fp.getCPtr(y), y);
   }

--- a/ffi/java/com/herumi/mcl/MclJNI.java
+++ b/ffi/java/com/herumi/mcl/MclJNI.java
@@ -69,6 +69,7 @@ public class MclJNI {
   public final static native long new_G1__SWIG_2(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native boolean G1_equals(long jarg1, G1 jarg1_, long jarg2, G1 jarg2_);
   public final static native boolean G1_isZero(long jarg1, G1 jarg1_);
+  public final static native boolean G1_isValidOrder(long jarg1, G1 jarg1_);
   public final static native void G1_set(long jarg1, G1 jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void G1_clear(long jarg1, G1 jarg1_);
   public final static native void G1_setStr__SWIG_0(long jarg1, G1 jarg1_, String jarg2, int jarg3);

--- a/ffi/java/com/herumi/mcl/MclJNI.java
+++ b/ffi/java/com/herumi/mcl/MclJNI.java
@@ -33,6 +33,7 @@ public class MclJNI {
   public final static native String Fr_toString__SWIG_0(long jarg1, Fr jarg1_, int jarg2);
   public final static native String Fr_toString__SWIG_1(long jarg1, Fr jarg1_);
   public final static native void Fr_deserialize(long jarg1, Fr jarg1_, byte[] jarg2);
+  public final static native void Fr_setLittleEndianMod(long jarg1, Fr jarg1_, byte[] jarg2);
   public final static native byte[] Fr_serialize(long jarg1, Fr jarg1_);
   public final static native void delete_Fr(long jarg1);
   public final static native void neg__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);

--- a/ffi/java/mcl_impl.hpp
+++ b/ffi/java/mcl_impl.hpp
@@ -29,6 +29,12 @@ void deserializeT(T& x, const char *cbuf, size_t bufSize)
 }
 
 template<class T>
+void setLittleEndianModT(T& x, const char *cbuf, size_t bufSize)
+{
+	x.setLittleEndianMod(cbuf, bufSize);
+}
+
+template<class T>
 void serializeT(std::string& out, const T& x)
 {
 	out.resize(48 * 12);
@@ -87,6 +93,10 @@ public:
 	void deserialize(const char *cbuf, size_t bufSize) throw(std::exception)
 	{
 		deserializeT(self_, cbuf, bufSize);
+	}
+	void setLittleEndianMod(const char *cbuf, size_t bufSize) throw(std::exception)
+	{
+		setLittleEndianModT(self_, cbuf, bufSize);
 	}
 	void serialize(std::string& out) const throw(std::exception)
 	{

--- a/ffi/java/mcl_impl.hpp
+++ b/ffi/java/mcl_impl.hpp
@@ -222,6 +222,7 @@ public:
 		: self_(x.self_, y.self_) { }
 	bool equals(const G1& rhs) const { return self_ == rhs.self_; }
 	bool isZero() const { return self_.isZero(); }
+	bool isValidOrder() const { return self_.isValidOrder(); }
 	void set(const Fp& x, const Fp& y) throw(std::exception)
 	{
 		self_.set(x.self_, y.self_);

--- a/ffi/java/mcl_wrap.cxx
+++ b/ffi/java/mcl_wrap.cxx
@@ -1592,6 +1592,19 @@ SWIGEXPORT jboolean JNICALL Java_com_herumi_mcl_MclJNI_G1_1isZero(JNIEnv *jenv, 
   return jresult;
 }
 
+SWIGEXPORT jboolean JNICALL Java_com_herumi_mcl_MclJNI_G1_1isValidOrder(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+    jboolean jresult = 0 ;
+    G1 *arg1 = (G1 *) 0 ;
+    bool result;
+
+    (void)jenv;
+    (void)jcls;
+    (void)jarg1_;
+    arg1 = *(G1 **)&jarg1;
+    result = (bool)((G1 const *)arg1)->isValidOrder();
+    jresult = (jboolean)result;
+    return jresult;
+}
 
 SWIGEXPORT void JNICALL Java_com_herumi_mcl_MclJNI_G1_1set(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2, jobject jarg2_, jlong jarg3, jobject jarg3_) {
   G1 *arg1 = (G1 *) 0 ;

--- a/ffi/java/mcl_wrap.cxx
+++ b/ffi/java/mcl_wrap.cxx
@@ -789,6 +789,37 @@ SWIGEXPORT void JNICALL Java_com_herumi_mcl_MclJNI_Fr_1deserialize(JNIEnv *jenv,
 }
 
 
+SWIGEXPORT void JNICALL Java_com_herumi_mcl_MclJNI_Fr_1setLittleEndianMod(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jbyteArray jarg2) {
+  Fr *arg1 = (Fr *) 0 ;
+  char *arg2 = (char *) 0 ;
+  size_t arg3 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(Fr **)&jarg1; 
+  {
+    if (jarg2) {
+      arg2 = (char *) jenv->GetByteArrayElements(jarg2, 0);
+      arg3 = (size_t) jenv->GetArrayLength(jarg2);
+    } else {
+      arg2 = 0;
+      arg3 = 0;
+    }
+  }
+  try {
+    (arg1)->setLittleEndianMod((char const *)arg2,arg3);
+  } catch(std::exception &_e) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, (&_e)->what());
+    return ;
+  }
+  {
+    if (jarg2) jenv->ReleaseByteArrayElements(jarg2, (jbyte *)arg2, 0);
+  }
+  
+}
+
+
 SWIGEXPORT jbyteArray JNICALL Java_com_herumi_mcl_MclJNI_Fr_1serialize(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jbyteArray jresult = 0 ;
   Fr *arg1 = (Fr *) 0 ;


### PR DESCRIPTION
Hello, I have added the two functions Fr.setLittleEndianMod() and G1.isValidOrder() to the JNI since I needed them for my use case. I think, it would be great if you could include these two functions in your repo as well.