### PR TITLE
[cs] add missing functions, some arithmetic operator overloads

### DIFF
--- a/ffi/cs/mcl/mcl.cs
+++ b/ffi/cs/mcl/mcl.cs
@@ -19,6 +19,7 @@ namespace mcl {
         [DllImport(dllName)] public static extern int mclBn_init(int curve, int compiledTimeVar);
         [DllImport(dllName)] public static extern void mclBn_setETHserialization(int enable);
         [DllImport(dllName)] public static extern int mclBn_setMapToMode(int mode);
+        [DllImport(dllName)] public static extern int mclBn_FrEvaluatePolynomial(ref Fr z, [In] Fr[] poly, long bufSize, in Fr y);
         [DllImport(dllName)] public static extern void mclBnFr_clear(ref Fr x);
         [DllImport(dllName)] public static extern void mclBnFr_setInt(ref Fr y, int x);
         [DllImport(dllName)] public static extern int mclBnFr_setStr(ref Fr x, [In][MarshalAs(UnmanagedType.LPStr)] string buf, long bufSize, int ioMode);
@@ -72,6 +73,7 @@ namespace mcl {
         [DllImport(dllName)] public static extern void mclBnG1_add(ref G1 z, in G1 x, in G1 y);
         [DllImport(dllName)] public static extern void mclBnG1_sub(ref G1 z, in G1 x, in G1 y);
         [DllImport(dllName)] public static extern void mclBnG1_mul(ref G1 z, in G1 x, in Fr y);
+        [DllImport(dllName)] public static extern void mclBnG1_mulVec(ref G1 x, [In]G1[] vec1, [In]Fr[] vec2, long bufSize);
 
         [DllImport(dllName)] public static extern void mclBnG2_clear(ref G2 x);
         [DllImport(dllName)] public static extern int mclBnG2_setStr(ref G2 x, [In][MarshalAs(UnmanagedType.LPStr)] string buf, long bufSize, int ioMode);
@@ -291,6 +293,14 @@ namespace mcl {
         [StructLayout(LayoutKind.Sequential)]
         public struct Fr {
             private U128 v0, v1;
+            public static Fr One()
+            {
+                var fr = new Fr();
+                fr.SetInt(1);
+
+                return fr;
+            }
+            public static Fr Zero() => new Fr();
             public void Clear()
             {
                 mclBnFr_clear(ref this);
@@ -433,6 +443,13 @@ namespace mcl {
         [StructLayout(LayoutKind.Sequential)]
         public struct Fp {
             private U128 v0, v1, v2;
+            public static Fp One()
+            {
+                var fp = new Fp();
+                fp.SetInt(1);
+                return fp;
+            }
+            public static Fp Zero() => new Fp();
             public void Clear()
             {
                 mclBnFp_clear(ref this);
@@ -648,6 +665,30 @@ namespace mcl {
             public void Mul(in G1 x, in Fr y)
             {
                 MCL.Mul(ref this, x, y);
+            }
+            public static G1 operator -(in G1 x)
+            {
+                var result = new G1();
+                result.Neg(x);
+                return result;
+            }
+            public static G1 operator +(in G1 left, in G1 right)
+            {
+                var result = new G1();
+                result.Add(left, right);
+                return result;
+            }
+            public static G1 operator -(in G1 left, in G1 right)
+            {
+                var result = new G1();
+                result.Sub(left, right);
+                return result;
+            }
+            public static G1 operator *(in G1 left, in Fr right)
+            {
+                var result = new G1();
+                result.Mul(left, right);
+                return result;
             }
         }
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Added some missing external functions, static factory for commonly used values, like `Fr.One();`.  Also some overloads of arithmetic operators on G1.