### PR TITLE
Add verifyOrderG1 and verifyOrderG2 to Java FFI

### DIFF
--- a/ffi/java/com/herumi/mcl/Mcl.java
+++ b/ffi/java/com/herumi/mcl/Mcl.java
@@ -125,4 +125,12 @@ public class Mcl implements MclConstants {
     MclJNI.inv__SWIG_2(GT.getCPtr(y), y, GT.getCPtr(x), x);
   }
 
+  public static void verifyOrderG1(boolean doVerify) {
+    MclJNI.verifyOrderG1(doVerify);
+  }
+
+  public static void verifyOrderG2(boolean doVerify) {
+    MclJNI.verifyOrderG2(doVerify);
+  }
+
 }

--- a/ffi/java/com/herumi/mcl/MclJNI.java
+++ b/ffi/java/com/herumi/mcl/MclJNI.java
@@ -123,4 +123,6 @@ public class MclJNI {
   public final static native void GT_deserialize(long jarg1, GT jarg1_, byte[] jarg2);
   public final static native byte[] GT_serialize(long jarg1, GT jarg1_);
   public final static native void delete_GT(long jarg1);
+  public final static native void verifyOrderG1(boolean jarg1);
+  public final static native void verifyOrderG2(boolean jarg1);
 }

--- a/ffi/java/java.md
+++ b/ffi/java/java.md
@@ -36,6 +36,8 @@ Mcl.SystemInit(curveType); // curveType = Mcl.BN254 or Mcl.BLS12_381
 * `Mcl.add(G1 z, G1 x, G1 y)` ; `z = x + y`
 * `Mcl.sub(G1 z, G1 x, G1 y)` ; `z = x - y`
 * `Mcl.mul(G1 z, G1 x, Fr y)` ; `z = x * y`
+* `Mcl.verifyOrderG1(boolean doVerify)` ; If set to `true`, `setStr` of `G1` will automatically check subgroup membership.
+Set to `false` by default, meaning only a on curve check is done by default.
 
 ## G2
 
@@ -44,6 +46,8 @@ Mcl.SystemInit(curveType); // curveType = Mcl.BN254 or Mcl.BLS12_381
 * `Mcl.add(G2 z, G2 x, G2 y)` ; `z = x + y`
 * `Mcl.sub(G2 z, G2 x, G2 y)` ; `z = x - y`
 * `Mcl.mul(G2 z, G2 x, Fr y)` ; `z = x * y`
+* `Mcl.verifyOrderG2(boolean doVerify)` ; If set to `true`, `setStr` of `G2` will automatically check subgroup membership.
+Set to `false` by default, meaning only a on curve check is done by default.
 
 ## GT
 

--- a/ffi/java/mcl_impl.hpp
+++ b/ffi/java/mcl_impl.hpp
@@ -465,6 +465,16 @@ void hashAndMapToG2(G2& P, const char *cbuf, size_t bufSize) throw(std::exceptio
 	mcl::bn::hashAndMapToG2(P.self_, cbuf, bufSize);
 }
 
+void verifyOrderG1(bool doVerify)
+{
+    mcl::bn::verifyOrderG1(doVerify);
+}
+
+void verifyOrderG2(bool doVerify)
+{
+    mcl::bn::verifyOrderG2(doVerify);
+}
+
 #if defined(__GNUC__) && !defined(__EMSCRIPTEN__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/ffi/java/mcl_wrap.cxx
+++ b/ffi/java/mcl_wrap.cxx
@@ -2760,6 +2760,26 @@ SWIGEXPORT void JNICALL Java_com_herumi_mcl_MclJNI_delete_1GT(JNIEnv *jenv, jcla
 }
 
 
+SWIGEXPORT void JNICALL Java_com_herumi_mcl_MclJNI_verifyOrderG1(JNIEnv *jenv, jclass jcls, jboolean jarg1) {
+  bool arg1 ;
+  
+  (void)jenv;
+  (void)jcls;
+  arg1 = jarg1 ? true : false; 
+  verifyOrderG1(arg1);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_herumi_mcl_MclJNI_verifyOrderG2(JNIEnv *jenv, jclass jcls, jboolean jarg1) {
+  bool arg1 ;
+  
+  (void)jenv;
+  (void)jcls;
+  arg1 = jarg1 ? true : false; 
+  verifyOrderG2(arg1);
+}
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This pull request adds the `verifyOrderG1` and `verifyOrderG2` methods to the Java FFI. I also added docs for those methods to the Java API doc. Am I right in my understanding that enabling these adds a subgroup check to the `setStr` method in addition to the default on curve check? 