### PR TITLE
Add MCL_MAP_TO_MODE_ETH2_LEGACY

### DIFF
--- a/include/mcl/bn.hpp
+++ b/include/mcl/bn.hpp
@@ -485,6 +485,10 @@ struct MapTo {
 			mapToMode_ = mode;
 			return true;
 			break;
+		case MCL_MAP_TO_MODE_ETH2_LEGACY:
+			mapToMode_ = mode;
+			return true;
+			break;
 		default:
 			return false;
 		}
@@ -509,7 +513,7 @@ struct MapTo {
 	template<class G, class F>
 	bool mapToEc(G& P, const F& t) const
 	{
-		if (mapToMode_ == MCL_MAP_TO_MODE_TRY_AND_INC) {
+		if (mapToMode_ == MCL_MAP_TO_MODE_TRY_AND_INC || mapToMode_ == MCL_MAP_TO_MODE_ETH2_LEGACY) {
 			ec::tryAndIncMapTo<G>(P, t);
 		} else {
 			if (!calcBN<G, F>(P, t)) return false;
@@ -557,7 +561,18 @@ struct MapTo {
 			return true;
 		}
 		if (!mapToEc(P, t)) return false;
+		if (mapToMode_ == MCL_MAP_TO_MODE_ETH2_LEGACY) {
+			Fp2 negY;
+			Fp2::neg(negY, P.y);
+			int cmp = Fp::compare(P.y.b, negY.b);
+			if (!(cmp > 0 || (cmp == 0 && P.y.a > negY.a))) {
+				P.y = negY;
+			}
+		}
 		mulByCofactor(P);
+		if (mapToMode_ == MCL_MAP_TO_MODE_ETH2_LEGACY) {
+			P *= g2cofactorAdj_;
+		}
 		return true;
 	}
 };

--- a/include/mcl/curve_type.h
+++ b/include/mcl/curve_type.h
@@ -47,6 +47,7 @@ enum {
 	MCL_MAP_TO_MODE_ORIGINAL, // see MapTo::calcBN
 	MCL_MAP_TO_MODE_TRY_AND_INC, // try-and-incremental-x
 	MCL_MAP_TO_MODE_ETH2, // (deprecated) old eth2.0 spec
+	MCL_MAP_TO_MODE_ETH2_LEGACY, // backwards compatible version of MCL_MAP_TO_MODE_ETH2 with commit 730c50d4eaff1e0d685a92ac8c896e873749471b
 	MCL_MAP_TO_MODE_WB19, // (deprecated) used in new eth2.0 spec
 	MCL_MAP_TO_MODE_HASH_TO_CURVE_05 = MCL_MAP_TO_MODE_WB19, // (deprecated) draft-irtf-cfrg-hash-to-curve-05
 	MCL_MAP_TO_MODE_HASH_TO_CURVE_06, // (deprecated) draft-irtf-cfrg-hash-to-curve-06


### PR DESCRIPTION
This pull request is to demonstrate backwards compatibility with commits before 730c50d4eaff1e0d685a92ac8c896e873749471b.  Specifically  `mapToG2(G2, Fp2)`  when used with `setMapToMode(MCL_MAP_TO_MODE_ETH2)`.  

I believe this was changed to match the evolving eth2 draft specification at the time. I work on a program that has produced many cryptographic artifacts using this functionality and have recently updated mcl. For that I've written my own backwards compat function that does *not* rely on changes to the current mcl library. Unfortunately it uses the internals of mcl which are obviously subject to change. Would you consider supporting this behavior at the API level?

Here are the commits where the functionality was removed:
 https://github.com/herumi/mcl/commit/730c50d4eaff1e0d685a92ac8c896e873749471b
 https://github.com/herumi/mcl/commit/48860008cdd133222de6bc8cc6e26b95f8af209b#diff-9
 