### PR TITLE
Fix java-ffi CMakeLists when GMP is installed on the system

### DIFF
--- a/ffi/java/CMakeLists.txt
+++ b/ffi/java/CMakeLists.txt
@@ -33,8 +33,6 @@ endif()
 # however, this configuration makes it possible to use both on all platforms, depending on what is available
 find_library(GMP_LIBRARY NAMES mpir gmp HINTS ${GMP_LINK_DIR} OPTIONAL)
 
-message (STATUS "MCL_LIBRARY=${MCL_LIBRARY} GMP_LIBRARY=${GMP_LIBRARY}")
-
 # make sure to always link mcl statically, so only one library needs to be installed by users
 set(CMAKE_FIND_LIBRARY_SUFFIXES .a .lib)
 
@@ -43,16 +41,20 @@ include_directories(${JNI_INCLUDE_DIRS} ../../include/ ../../include/cybozu)
 
 find_library(MCL_LIBRARY NAMES mcl HINTS ${MCL_LINK_DIR} REQUIRED)
 
-if((GMP_LIBRARY_FOUND))
+if(GMP_LIBRARY)
+	message(STATUS "GMP found - linking it.")
 	include_directories(../../external/cybozulib_ext/include)
 	target_link_libraries(mcljava ${GMP_LIBRARY})
 	target_link_libraries(mclelgamaljava ${GMP_LIBRARY})
 else()
+	message(STATUS "GMP not found - assuming VINT was used to compile MCL.")
 	add_definitions(-DMCL_USE_VINT -DMCL_VINT_FIXED_BUFFER)
 endif()
 
 target_link_libraries(mcljava ${MCL_LIBRARY})
 target_link_libraries(mclelgamaljava ${MCL_LIBRARY})
+
+message (STATUS "MCL_LIBRARY=${MCL_LIBRARY} GMP_LIBRARY=${GMP_LIBRARY}")
 
 # finally, compile the test Java classes
 find_package(Java REQUIRED)


### PR DESCRIPTION
I have realized that the CMakeLists.txt always assumes that mcl was compiled without GMP and uses the defines for VINT.  
This leads to ugly run-time errors when the library tries to init mcl with VINT, but should really use the GMP-specific methods.  
This PR should fix it.  
Tested on Ubuntu 20.04LTS GNU/Linux with GMP and Windows 10 without GMP.