### PR TITLE
Updated how AR is passed and used in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,22 +216,22 @@ ifeq ($(OS),mingw64)
 endif
 
 $(MCL_LIB): $(LIB_OBJ)
-	$(AR) $@ $(LIB_OBJ)
+	$(AR) r $@ $(LIB_OBJ)
 
 $(MCL_SLIB): $(LIB_OBJ)
 	$(PRE)$(CXX) -o $@ $(LIB_OBJ) -shared $(LDFLAGS) $(MCL_SLIB_LDFLAGS)
 
 $(BN256_LIB): $(BN256_OBJ)
-	$(AR) $@ $(BN256_OBJ)
+	$(AR) r $@ $(BN256_OBJ)
 
 $(SHE256_LIB): $(SHE256_OBJ)
-	$(AR) $@ $(SHE256_OBJ)
+	$(AR) r $@ $(SHE256_OBJ)
 
 $(SHE384_LIB): $(SHE384_OBJ)
-	$(AR) $@ $(SHE384_OBJ)
+	$(AR) r $@ $(SHE384_OBJ)
 
 $(SHE384_256_LIB): $(SHE384_256_OBJ)
-	$(AR) $@ $(SHE384_256_OBJ)
+	$(AR) r $@ $(SHE384_256_OBJ)
 
 $(SHE256_SLIB): $(SHE256_OBJ) $(MCL_LIB)
 	$(PRE)$(CXX) -o $@ $(SHE256_OBJ) $(MCL_LIB) -shared $(LDFLAGS) $(SHE256_SLIB_LDFLAGS)
@@ -246,13 +246,13 @@ $(BN256_SLIB): $(BN256_OBJ) $(MCL_SLIB)
 	$(PRE)$(CXX) -o $@ $(BN256_OBJ) -shared $(LDFLAGS) $(BN256_SLIB_LDFLAGS)
 
 $(BN384_LIB): $(BN384_OBJ)
-	$(AR) $@ $(BN384_OBJ)
+	$(AR) r $@ $(BN384_OBJ)
 
 $(BN384_256_LIB): $(BN384_256_OBJ)
-	$(AR) $@ $(BN384_256_OBJ)
+	$(AR) r $@ $(BN384_256_OBJ)
 
 $(BN512_LIB): $(BN512_OBJ)
-	$(AR) $@ $(BN512_OBJ)
+	$(AR) r $@ $(BN512_OBJ)
 
 $(BN384_SLIB): $(BN384_OBJ) $(MCL_SLIB)
 	$(PRE)$(CXX) -o $@ $(BN384_OBJ) -shared $(LDFLAGS) $(BN384_SLIB_LDFLAGS)
@@ -265,7 +265,7 @@ $(BN512_SLIB): $(BN512_OBJ) $(MCL_SLIB)
 
 ECDSA_OBJ=$(OBJ_DIR)/ecdsa_c.o
 $(ECDSA_LIB): $(ECDSA_OBJ)
-	$(AR) $@ $(ECDSA_OBJ)
+	$(AR) r $@ $(ECDSA_OBJ)
 
 $(ASM_OBJ): $(ASM_SRC)
 	$(PRE)$(CXX) -c $< -o $@ $(CFLAGS)

--- a/common.mk
+++ b/common.mk
@@ -73,8 +73,8 @@ ifeq ($(ARCH),s390x)
   BIT=64
 endif
 
+AR?=ar
 CP=cp -f
-AR=ar r
 MKDIR=mkdir -p
 RM=rm -rf
 


### PR DESCRIPTION
Added support for passing custom AR command during builds

This is a fix for cross compiling via linux to darwin