### PR TITLE
Updated `inline const CurveParam* getCurveParam(int type)` to return `nullptr`

### DIFF
--- a/include/mcl/curve_type.h
+++ b/include/mcl/curve_type.h
@@ -116,7 +116,7 @@ inline const CurveParam* getCurveParam(int type)
 	case MCL_BLS12_381: return &mcl::BLS12_381;
 	case MCL_BN160: return &mcl::BN160;
 	default:
-		return 0;
+		return nullptr;
 	}
 }
 #ifdef __clang__


### PR DESCRIPTION
Updated `inline const CurveParam* getCurveParam(int type)` to return `nullptr` instead of 0 to keep clang-tidy happy