### PR TITLE
fix 'make sample' error

### DIFF
--- a/sample/rawbench.cpp
+++ b/sample/rawbench.cpp
@@ -19,7 +19,7 @@ void mul9(const mcl::fp::Op& op, Unit *y, const Unit *x, const Unit *p)
 
 void benchRaw(const char *p, mcl::fp::Mode mode)
 {
-	Fp::init(1, p, mode);
+	Fp::init(p, 1, mode);
 	Fp2::init();
 	const size_t maxN = sizeof(Fp) / sizeof(Unit);
 	const mcl::fp::Op& op = Fp::getOp();


### PR DESCRIPTION
This fixes the following error of `make sample`.

```console
sample/rawbench.cpp:22:17: error: no matching function for call to ‘init(int, const char*&, mcl::fp::Mode&)’
   22 |         Fp::init(1, p, mode);
```
