### PR TITLE
feat: add Rust FFI bindings for BN254

### DIFF
--- a/ffi/rust/Cargo.toml
+++ b/ffi/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mcl-bn254"
+version = "0.1.0"
+edition = "2021"
+description = "Rust FFI bindings for herumi/mcl BN254 curve operations"
+license = "BSD-3-Clause"
+repository = "https://github.com/herumi/mcl"
+keywords = ["bn254", "pairing", "cryptography", "ecc", "mcl"]
+categories = ["cryptography"]
+build = "build.rs"
+
+[build-dependencies]
+cmake = "0.1"

--- a/ffi/rust/README.md
+++ b/ffi/rust/README.md
@@ -1,0 +1,65 @@
+# mcl-bn254
+
+Rust FFI bindings for [herumi/mcl](https://github.com/herumi/mcl) BN254 curve operations.
+
+Provides safe wrappers for G1/G2 point arithmetic and optimal ate pairings on the BN254 curve, with serialization matching Ethereum's precompile format (big-endian).
+
+## Features
+
+- **G1 operations**: addition, scalar multiplication, negation, doubling
+- **G2 operations**: addition, scalar multiplication, negation
+- **Pairing**: optimal ate pairing, Miller loop, final exponentiation
+- **Ethereum format**: big-endian serialization matching EIP-196/197
+- **Operator overloads**: `+`, `-`, `*`, `-` (unary) for ergonomic arithmetic
+- **No runtime dependencies**: pure FFI to the mcl C++ library
+
+## Requirements
+
+- **CMake** (for building the mcl C++ library)
+- **Clang** (required by mcl on most platforms)
+
+## Usage
+
+```rust
+use mcl_bn254::{init, G1, G2, Fr, pairing, pairing_check};
+
+// Initialize (must be called once before any operations)
+assert!(init());
+
+// Parse G1/G2 points from Ethereum-format bytes (big-endian)
+let g1 = G1::from_eth(&g1_bytes).expect("valid G1 point");
+let g2 = G2::from_eth(&g2_bytes).expect("valid G2 point");
+
+// Point arithmetic
+let sum = g1.add(&other_g1);      // or: g1 + other_g1
+let product = g1.mul(&scalar);     // or: g1 * scalar
+
+// Pairing check (Ethereum ecPairing precompile)
+let result = pairing_check(&[g1_a, g1_b], &[g2_a, g2_b]);
+```
+
+## Building
+
+```bash
+cd ffi/rust
+cargo build
+cargo test
+cargo run --example pairing
+```
+
+## Serialization Format
+
+All serialization follows the Ethereum precompile format:
+
+| Type | Size | Format |
+|------|------|--------|
+| Fp   | 32 bytes | big-endian |
+| Fr   | 32 bytes | big-endian |
+| G1   | 64 bytes | `x (32B) \|\| y (32B)` |
+| G2   | 128 bytes | `x_im (32B) \|\| x_re (32B) \|\| y_im (32B) \|\| y_re (32B)` |
+
+Point at infinity is represented as all zeros.
+
+## License
+
+BSD-3-Clause (same as herumi/mcl)

--- a/ffi/rust/build.rs
+++ b/ffi/rust/build.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+    let mcl_root = manifest_dir.join("../..").canonicalize().unwrap();
+
+    let mut config = cmake::Config::new(&mcl_root);
+
+    config
+        .define("MCL_FP_BIT", "256")
+        .define("MCL_FR_BIT", "256")
+        .define("MCL_STANDALONE", "ON")
+        .define("MCL_BUILD_TESTING", "OFF")
+        .define("MCL_BUILD_SAMPLE", "OFF");
+
+    // mcl requires clang++ for compiling .ll files on non-x86_64-Linux platforms.
+    // On macOS the default compiler is already clang++.
+    // On Linux ARM64 (and other non-x86_64 arches) we need to set it explicitly.
+    if cfg!(target_os = "linux") && !cfg!(target_arch = "x86_64") {
+        config.define("CMAKE_CXX_COMPILER", "clang++");
+    }
+
+    let dst = config.build_target("mcl_st").build();
+
+    println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
+    println!("cargo:rustc-link-lib=static=mcl");
+
+    // Link C++ standard library (needed by mcl's C++ code)
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=c++");
+    } else if cfg!(target_os = "linux") {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
+}

--- a/ffi/rust/examples/pairing.rs
+++ b/ffi/rust/examples/pairing.rs
@@ -1,0 +1,95 @@
+//! Simple BN254 pairing example.
+//!
+//! Demonstrates:
+//! - Initializing the library
+//! - Parsing G1/G2 points from Ethereum-format hex
+//! - Computing a pairing check
+
+use mcl_bn254::{init, pairing, pairing_check, Fr, G1, G2};
+
+fn hex_to_array<const N: usize>(s: &str) -> [u8; N] {
+    let bytes: Vec<u8> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect();
+    let mut arr = [0u8; N];
+    arr.copy_from_slice(&bytes);
+    arr
+}
+
+fn main() {
+    // Initialize BN254 curve
+    assert!(init(), "mcl initialization failed");
+    println!("mcl BN254 initialized (version: {})", mcl_bn254::bn254::get_version());
+
+    // --- G1 point addition ---
+    let p1 = G1::from_eth(&hex_to_array::<64>(
+        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9\
+         063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+    ))
+    .expect("valid G1 point");
+
+    let p2 = G1::from_eth(&hex_to_array::<64>(
+        "07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed\
+         06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
+    ))
+    .expect("valid G1 point");
+
+    let sum = p1.add(&p2);
+    println!("G1 addition: OK (result is_zero={})", sum.is_zero());
+
+    // --- Scalar multiplication ---
+    let scalar = Fr::from_be_bytes(&hex_to_array::<32>(
+        "00000000000000000000000000000000000000000000000011138ce750fa15c2",
+    ));
+    let product = p1.mul(&scalar);
+    println!("G1 scalar mul: OK (result is_zero={})", product.is_zero());
+
+    // --- Pairing ---
+    let g1 = G1::from_eth(&hex_to_array::<64>(
+        "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59\
+         3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41",
+    ))
+    .expect("valid G1 point");
+
+    let g2 = G2::from_eth(&hex_to_array::<128>(
+        "209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7\
+         04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678\
+         2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d\
+         120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550",
+    ))
+    .expect("valid G2 point");
+
+    let gt = pairing(&g1, &g2);
+    println!("Pairing computed: is_one={}", gt.is_one());
+
+    // --- Pairing check (Ethereum ecPairing precompile) ---
+    let input = hex_to_array::<384>(
+        "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59\
+         3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41\
+         209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7\
+         04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678\
+         2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d\
+         120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550\
+         111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c\
+         2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411\
+         198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2\
+         1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed\
+         090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b\
+         12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+    );
+
+    let g1_a = G1::from_eth(input[0..64].try_into().unwrap()).unwrap();
+    let g2_a = G2::from_eth(input[64..192].try_into().unwrap()).unwrap();
+    let g1_b = G1::from_eth(input[192..256].try_into().unwrap()).unwrap();
+    let g2_b = G2::from_eth(input[256..384].try_into().unwrap()).unwrap();
+
+    let check = pairing_check(&[g1_a, g1_b], &[g2_a, g2_b]);
+    println!("Pairing check (2 pairs): {}", check);
+
+    // Empty pairing check
+    let empty_check = pairing_check(&[], &[]);
+    println!("Empty pairing check: {}", empty_check);
+
+    println!("\nAll operations completed successfully!");
+}

--- a/ffi/rust/src/bn254.rs
+++ b/ffi/rust/src/bn254.rs
@@ -1,0 +1,620 @@
+//! Safe Rust wrappers for BN254 curve operations.
+//!
+//! Provides types and functions for G1/G2 point arithmetic and pairings,
+//! with serialization matching the Ethereum precompile format (big-endian).
+
+use crate::ffi;
+use std::ops::{Add, Mul, Neg, Sub};
+use std::sync::OnceLock;
+
+/// MCL_BN_SNARK1 curve type constant (a.k.a. alt_bn128 / bn256 / BN254 in Ethereum).
+const MCL_BN_SNARK1: i32 = 4;
+
+/// Compiled-time variable: FR_UNIT_SIZE(4) * 10 + FP_UNIT_SIZE(4) = 44.
+const MCLBN_COMPILED_TIME_VAR: i32 = 44;
+
+/// Size of a field element in bytes (256 bits).
+const FP_SIZE: usize = 32;
+
+static INIT: OnceLock<bool> = OnceLock::new();
+
+/// Initialize the BN254 curve.
+///
+/// Must be called before any other operations in this module.
+/// Safe to call multiple times; initialization happens only once.
+/// Returns `true` if initialization succeeded.
+pub fn init() -> bool {
+    *INIT.get_or_init(|| unsafe { ffi::mclBn_init(MCL_BN_SNARK1, MCLBN_COMPILED_TIME_VAR) == 0 })
+}
+
+/// Returns the mcl library version.
+pub fn get_version() -> u32 {
+    unsafe { ffi::mclBn_getVersion() }
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+/// Reverse a byte slice in place (big-endian <-> little-endian).
+#[inline]
+fn reverse_32(bytes: &[u8; FP_SIZE]) -> [u8; FP_SIZE] {
+    let mut out = *bytes;
+    out.reverse();
+    out
+}
+
+// ── Fp (base field element) ──────────────────────────────────────────────────
+
+/// Base field element of BN254.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct Fp(pub(crate) ffi::MclBnFp);
+
+impl Fp {
+    /// The additive identity (zero).
+    pub fn zero() -> Self {
+        let mut fp = Self(ffi::MclBnFp { d: [0u64; 4] });
+        unsafe { ffi::mclBnFp_clear(&mut fp.0) };
+        fp
+    }
+
+    /// The multiplicative identity (one).
+    pub fn one() -> Self {
+        let mut fp = Self(ffi::MclBnFp { d: [0u64; 4] });
+        unsafe { ffi::mclBnFp_setInt32(&mut fp.0, 1) };
+        fp
+    }
+
+    pub fn is_zero(&self) -> bool {
+        unsafe { ffi::mclBnFp_isZero(&self.0) == 1 }
+    }
+
+    /// Deserialize from 32-byte big-endian representation.
+    /// Returns `None` if the value is not a valid field element (>= modulus).
+    pub fn from_be_bytes(bytes: &[u8; FP_SIZE]) -> Option<Self> {
+        let le = reverse_32(bytes);
+        let mut fp = Self(ffi::MclBnFp { d: [0u64; 4] });
+        let n = unsafe { ffi::mclBnFp_deserialize(&mut fp.0, le.as_ptr(), FP_SIZE) };
+        if n == 0 {
+            None
+        } else {
+            Some(fp)
+        }
+    }
+
+    /// Serialize to 32-byte big-endian representation.
+    pub fn to_be_bytes(&self) -> [u8; FP_SIZE] {
+        let mut buf = [0u8; FP_SIZE];
+        let n = unsafe { ffi::mclBnFp_serialize(buf.as_mut_ptr(), FP_SIZE, &self.0) };
+        assert_eq!(n, FP_SIZE);
+        buf.reverse();
+        buf
+    }
+}
+
+impl PartialEq for Fp {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { ffi::mclBnFp_isEqual(&self.0, &other.0) == 1 }
+    }
+}
+
+impl Eq for Fp {}
+
+// ── Fr (scalar field element) ────────────────────────────────────────────────
+
+/// Scalar field element of the BN254 curve.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct Fr(pub(crate) ffi::MclBnFr);
+
+impl Fr {
+    /// The additive identity (zero).
+    pub fn zero() -> Self {
+        let mut fr = Self(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_clear(&mut fr.0) };
+        fr
+    }
+
+    /// The multiplicative identity (one).
+    pub fn one() -> Self {
+        let mut fr = Self(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_setInt32(&mut fr.0, 1) };
+        fr
+    }
+
+    pub fn is_zero(&self) -> bool {
+        unsafe { ffi::mclBnFr_isZero(&self.0) == 1 }
+    }
+
+    pub fn is_one(&self) -> bool {
+        unsafe { ffi::mclBnFr_isOne(&self.0) == 1 }
+    }
+
+    /// Deserialize from 32-byte big-endian representation.
+    /// The value is reduced modulo the scalar field order.
+    pub fn from_be_bytes(bytes: &[u8; 32]) -> Self {
+        let le = reverse_32(bytes);
+        let mut fr = Self(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_setLittleEndianMod(&mut fr.0, le.as_ptr(), 32) };
+        fr
+    }
+
+    /// Serialize to 32-byte big-endian representation.
+    pub fn to_be_bytes(&self) -> [u8; 32] {
+        let mut buf = [0u8; 32];
+        let n = unsafe { ffi::mclBnFr_serialize(buf.as_mut_ptr(), 32, &self.0) };
+        assert_eq!(n, 32);
+        buf.reverse();
+        buf
+    }
+
+    /// Generate a random scalar using a CSPRNG.
+    pub fn random() -> Self {
+        let mut fr = Self(ffi::MclBnFr { d: [0u64; 4] });
+        let ret = unsafe { ffi::mclBnFr_setByCSPRNG(&mut fr.0) };
+        assert_eq!(ret, 0, "CSPRNG failed");
+        fr
+    }
+
+    /// Multiplicative inverse. Panics if self is zero.
+    pub fn inv(&self) -> Self {
+        let mut result = Self(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_inv(&mut result.0, &self.0) };
+        result
+    }
+}
+
+impl PartialEq for Fr {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { ffi::mclBnFr_isEqual(&self.0, &other.0) == 1 }
+    }
+}
+
+impl Eq for Fr {}
+
+impl Add for Fr {
+    type Output = Fr;
+    fn add(self, rhs: Fr) -> Fr {
+        let mut z = Fr(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_add(&mut z.0, &self.0, &rhs.0) };
+        z
+    }
+}
+
+impl Sub for Fr {
+    type Output = Fr;
+    fn sub(self, rhs: Fr) -> Fr {
+        let mut z = Fr(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_sub(&mut z.0, &self.0, &rhs.0) };
+        z
+    }
+}
+
+impl Mul for Fr {
+    type Output = Fr;
+    fn mul(self, rhs: Fr) -> Fr {
+        let mut z = Fr(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_mul(&mut z.0, &self.0, &rhs.0) };
+        z
+    }
+}
+
+impl Neg for Fr {
+    type Output = Fr;
+    fn neg(self) -> Fr {
+        let mut z = Fr(ffi::MclBnFr { d: [0u64; 4] });
+        unsafe { ffi::mclBnFr_neg(&mut z.0, &self.0) };
+        z
+    }
+}
+
+// ── G1 (curve point over Fp) ─────────────────────────────────────────────────
+
+/// A point on the BN254 G1 curve (over Fp).
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct G1(pub(crate) ffi::MclBnG1);
+
+impl G1 {
+    /// The point at infinity (identity element).
+    pub fn zero() -> Self {
+        let mut g1 = Self(ffi::MclBnG1 {
+            x: ffi::MclBnFp { d: [0u64; 4] },
+            y: ffi::MclBnFp { d: [0u64; 4] },
+            z: ffi::MclBnFp { d: [0u64; 4] },
+        });
+        unsafe { ffi::mclBnG1_clear(&mut g1.0) };
+        g1
+    }
+
+    pub fn is_zero(&self) -> bool {
+        unsafe { ffi::mclBnG1_isZero(&self.0) == 1 }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        unsafe { ffi::mclBnG1_isValid(&self.0) == 1 }
+    }
+
+    /// Deserialize from Ethereum format: `x (32 bytes BE) || y (32 bytes BE)`.
+    /// Returns `None` if coordinates are invalid or the point is not on the curve.
+    pub fn from_eth(bytes: &[u8; 64]) -> Option<Self> {
+        let x = Fp::from_be_bytes(bytes[0..32].try_into().unwrap())?;
+        let y = Fp::from_be_bytes(bytes[32..64].try_into().unwrap())?;
+
+        if x.is_zero() && y.is_zero() {
+            return Some(G1::zero());
+        }
+
+        let g1 = Self(ffi::MclBnG1 {
+            x: x.0,
+            y: y.0,
+            z: Fp::one().0,
+        });
+
+        if !g1.is_valid() {
+            return None;
+        }
+
+        Some(g1)
+    }
+
+    /// Serialize to Ethereum format: `x (32 bytes BE) || y (32 bytes BE)`.
+    pub fn to_eth(&self) -> [u8; 64] {
+        if self.is_zero() {
+            return [0u8; 64];
+        }
+
+        let mut normalized = *self;
+        unsafe { ffi::mclBnG1_normalize(&mut normalized.0, &self.0) };
+
+        let x = Fp(normalized.0.x);
+        let y = Fp(normalized.0.y);
+
+        let mut result = [0u8; 64];
+        result[0..32].copy_from_slice(&x.to_be_bytes());
+        result[32..64].copy_from_slice(&y.to_be_bytes());
+        result
+    }
+
+    /// Point addition.
+    pub fn add(&self, other: &G1) -> G1 {
+        let mut z = G1::zero();
+        unsafe { ffi::mclBnG1_add(&mut z.0, &self.0, &other.0) };
+        z
+    }
+
+    /// Point subtraction.
+    pub fn sub(&self, other: &G1) -> G1 {
+        let mut z = G1::zero();
+        unsafe { ffi::mclBnG1_sub(&mut z.0, &self.0, &other.0) };
+        z
+    }
+
+    /// Point negation.
+    pub fn neg(&self) -> G1 {
+        let mut z = G1::zero();
+        unsafe { ffi::mclBnG1_neg(&mut z.0, &self.0) };
+        z
+    }
+
+    /// Point doubling.
+    pub fn dbl(&self) -> G1 {
+        let mut z = G1::zero();
+        unsafe { ffi::mclBnG1_dbl(&mut z.0, &self.0) };
+        z
+    }
+
+    /// Scalar multiplication.
+    pub fn mul(&self, scalar: &Fr) -> G1 {
+        let mut z = G1::zero();
+        unsafe { ffi::mclBnG1_mul(&mut z.0, &self.0, &scalar.0) };
+        z
+    }
+
+    /// Constant-time scalar multiplication (resistant to timing side-channels).
+    pub fn mul_ct(&self, scalar: &Fr) -> G1 {
+        let mut z = G1::zero();
+        unsafe { ffi::mclBnG1_mulCT(&mut z.0, &self.0, &scalar.0) };
+        z
+    }
+
+    /// Hash arbitrary data to a G1 point.
+    pub fn hash_and_map_to(msg: &[u8]) -> Option<Self> {
+        let mut g1 = G1::zero();
+        let ret = unsafe { ffi::mclBnG1_hashAndMapTo(&mut g1.0, msg.as_ptr(), msg.len()) };
+        if ret == 0 {
+            Some(g1)
+        } else {
+            None
+        }
+    }
+}
+
+impl PartialEq for G1 {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { ffi::mclBnG1_isEqual(&self.0, &other.0) == 1 }
+    }
+}
+
+impl Eq for G1 {}
+
+impl Add for G1 {
+    type Output = G1;
+    fn add(self, rhs: G1) -> G1 {
+        G1::add(&self, &rhs)
+    }
+}
+
+impl Sub for G1 {
+    type Output = G1;
+    fn sub(self, rhs: G1) -> G1 {
+        G1::sub(&self, &rhs)
+    }
+}
+
+impl Neg for G1 {
+    type Output = G1;
+    fn neg(self) -> G1 {
+        G1::neg(&self)
+    }
+}
+
+impl Mul<Fr> for G1 {
+    type Output = G1;
+    fn mul(self, rhs: Fr) -> G1 {
+        G1::mul(&self, &rhs)
+    }
+}
+
+// ── G2 (curve point over Fp2) ────────────────────────────────────────────────
+
+/// A point on the BN254 G2 curve (over Fp2).
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct G2(pub(crate) ffi::MclBnG2);
+
+impl G2 {
+    /// The point at infinity (identity element).
+    pub fn zero() -> Self {
+        let mut g2 = Self(ffi::MclBnG2 {
+            x: ffi::MclBnFp2 {
+                d: [ffi::MclBnFp { d: [0u64; 4] }; 2],
+            },
+            y: ffi::MclBnFp2 {
+                d: [ffi::MclBnFp { d: [0u64; 4] }; 2],
+            },
+            z: ffi::MclBnFp2 {
+                d: [ffi::MclBnFp { d: [0u64; 4] }; 2],
+            },
+        });
+        unsafe { ffi::mclBnG2_clear(&mut g2.0) };
+        g2
+    }
+
+    pub fn is_zero(&self) -> bool {
+        unsafe { ffi::mclBnG2_isZero(&self.0) == 1 }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        unsafe { ffi::mclBnG2_isValid(&self.0) == 1 }
+    }
+
+    /// Deserialize from Ethereum format (128 bytes):
+    /// `x_im (32B) || x_re (32B) || y_im (32B) || y_re (32B)`, all big-endian.
+    ///
+    /// Returns `None` if coordinates are invalid or the point is not on the curve.
+    pub fn from_eth(bytes: &[u8; 128]) -> Option<Self> {
+        let x_im = Fp::from_be_bytes(bytes[0..32].try_into().unwrap())?;
+        let x_re = Fp::from_be_bytes(bytes[32..64].try_into().unwrap())?;
+        let y_im = Fp::from_be_bytes(bytes[64..96].try_into().unwrap())?;
+        let y_re = Fp::from_be_bytes(bytes[96..128].try_into().unwrap())?;
+
+        if x_im.is_zero() && x_re.is_zero() && y_im.is_zero() && y_re.is_zero() {
+            return Some(G2::zero());
+        }
+
+        // Fp2: d[0] = real, d[1] = imaginary
+        let g2 = Self(ffi::MclBnG2 {
+            x: ffi::MclBnFp2 {
+                d: [x_re.0, x_im.0],
+            },
+            y: ffi::MclBnFp2 {
+                d: [y_re.0, y_im.0],
+            },
+            z: ffi::MclBnFp2 {
+                d: [Fp::one().0, Fp::zero().0],
+            },
+        });
+
+        if !g2.is_valid() {
+            return None;
+        }
+
+        Some(g2)
+    }
+
+    /// Serialize to Ethereum format (128 bytes):
+    /// `x_im (32B) || x_re (32B) || y_im (32B) || y_re (32B)`, all big-endian.
+    pub fn to_eth(&self) -> [u8; 128] {
+        if self.is_zero() {
+            return [0u8; 128];
+        }
+
+        let mut normalized = *self;
+        unsafe { ffi::mclBnG2_normalize(&mut normalized.0, &self.0) };
+
+        let x_re = Fp(normalized.0.x.d[0]);
+        let x_im = Fp(normalized.0.x.d[1]);
+        let y_re = Fp(normalized.0.y.d[0]);
+        let y_im = Fp(normalized.0.y.d[1]);
+
+        let mut result = [0u8; 128];
+        result[0..32].copy_from_slice(&x_im.to_be_bytes());
+        result[32..64].copy_from_slice(&x_re.to_be_bytes());
+        result[64..96].copy_from_slice(&y_im.to_be_bytes());
+        result[96..128].copy_from_slice(&y_re.to_be_bytes());
+        result
+    }
+
+    /// Point addition.
+    pub fn add(&self, other: &G2) -> G2 {
+        let mut z = G2::zero();
+        unsafe { ffi::mclBnG2_add(&mut z.0, &self.0, &other.0) };
+        z
+    }
+
+    /// Point negation.
+    pub fn neg(&self) -> G2 {
+        let mut z = G2::zero();
+        unsafe { ffi::mclBnG2_neg(&mut z.0, &self.0) };
+        z
+    }
+
+    /// Scalar multiplication.
+    pub fn mul(&self, scalar: &Fr) -> G2 {
+        let mut z = G2::zero();
+        unsafe { ffi::mclBnG2_mul(&mut z.0, &self.0, &scalar.0) };
+        z
+    }
+
+    /// Hash arbitrary data to a G2 point.
+    pub fn hash_and_map_to(msg: &[u8]) -> Option<Self> {
+        let mut g2 = G2::zero();
+        let ret = unsafe { ffi::mclBnG2_hashAndMapTo(&mut g2.0, msg.as_ptr(), msg.len()) };
+        if ret == 0 {
+            Some(g2)
+        } else {
+            None
+        }
+    }
+}
+
+impl PartialEq for G2 {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { ffi::mclBnG2_isEqual(&self.0, &other.0) == 1 }
+    }
+}
+
+impl Eq for G2 {}
+
+impl Add for G2 {
+    type Output = G2;
+    fn add(self, rhs: G2) -> G2 {
+        G2::add(&self, &rhs)
+    }
+}
+
+impl Neg for G2 {
+    type Output = G2;
+    fn neg(self) -> G2 {
+        G2::neg(&self)
+    }
+}
+
+// ── GT (target group element in Fp12) ────────────────────────────────────────
+
+/// An element of the target group GT (a subgroup of Fp12).
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct GT(pub(crate) ffi::MclBnGT);
+
+impl GT {
+    /// Returns `true` if this is the identity element of GT.
+    pub fn is_one(&self) -> bool {
+        unsafe { ffi::mclBnGT_isOne(&self.0) == 1 }
+    }
+
+    /// Group multiplication in GT.
+    pub fn mul(&self, other: &GT) -> GT {
+        let mut z = Self::default();
+        unsafe { ffi::mclBnGT_mul(&mut z.0, &self.0, &other.0) };
+        z
+    }
+
+    /// Exponentiation in GT.
+    pub fn pow(&self, exp: &Fr) -> GT {
+        let mut z = Self::default();
+        unsafe { ffi::mclBnGT_pow(&mut z.0, &self.0, &exp.0) };
+        z
+    }
+
+    /// Inverse in GT.
+    pub fn inv(&self) -> GT {
+        let mut z = Self::default();
+        unsafe { ffi::mclBnGT_inv(&mut z.0, &self.0) };
+        z
+    }
+}
+
+impl Default for GT {
+    fn default() -> Self {
+        Self(ffi::MclBnGT {
+            d: [ffi::MclBnFp { d: [0u64; 4] }; 12],
+        })
+    }
+}
+
+impl PartialEq for GT {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { ffi::mclBnGT_isEqual(&self.0, &other.0) == 1 }
+    }
+}
+
+impl Eq for GT {}
+
+// ── Pairing operations ───────────────────────────────────────────────────────
+
+/// Compute the optimal ate pairing: `e(g1, g2)`.
+pub fn pairing(g1: &G1, g2: &G2) -> GT {
+    let mut z = GT::default();
+    unsafe { ffi::mclBn_pairing(&mut z.0, &g1.0, &g2.0) };
+    z
+}
+
+/// Compute the Miller loop for a single pair.
+pub fn miller_loop(g1: &G1, g2: &G2) -> GT {
+    let mut z = GT::default();
+    unsafe { ffi::mclBn_millerLoop(&mut z.0, &g1.0, &g2.0) };
+    z
+}
+
+/// Compute the product of Miller loops: `prod_i millerLoop(g1s[i], g2s[i])`.
+///
+/// This is more efficient than computing individual Miller loops and multiplying.
+/// Panics if `g1s` and `g2s` have different lengths.
+pub fn multi_miller_loop(g1s: &[G1], g2s: &[G2]) -> GT {
+    assert_eq!(g1s.len(), g2s.len());
+
+    if g1s.is_empty() {
+        let mut z = GT::default();
+        unsafe { ffi::mclBnGT_setInt32(&mut z.0, 1) };
+        return z;
+    }
+
+    let mut z = GT::default();
+    unsafe {
+        ffi::mclBn_millerLoopVec(
+            &mut z.0,
+            g1s.as_ptr() as *const ffi::MclBnG1,
+            g2s.as_ptr() as *const ffi::MclBnG2,
+            g1s.len(),
+        );
+    }
+    z
+}
+
+/// Compute the final exponentiation step of the pairing.
+pub fn final_exp(gt: &GT) -> GT {
+    let mut z = GT::default();
+    unsafe { ffi::mclBn_finalExp(&mut z.0, &gt.0) };
+    z
+}
+
+/// Check that `e(g1s[0], g2s[0]) * ... * e(g1s[n-1], g2s[n-1]) == 1` in GT.
+///
+/// This is the standard pairing check used by Ethereum's ecPairing precompile.
+/// Returns `true` if the pairing product equals the identity element.
+pub fn pairing_check(g1s: &[G1], g2s: &[G2]) -> bool {
+    let ml = multi_miller_loop(g1s, g2s);
+    let result = final_exp(&ml);
+    result.is_one()
+}

--- a/ffi/rust/src/ffi.rs
+++ b/ffi/rust/src/ffi.rs
@@ -1,0 +1,151 @@
+//! Raw FFI bindings to herumi/mcl's C API (bn.h) for BN254.
+//!
+//! All types use `MCL_FP_BIT=256`, `MCL_FR_BIT=256`:
+//! - `MCLBN_FP_UNIT_SIZE = 4`
+//! - `MCLBN_FR_UNIT_SIZE = 4`
+//! - `MCLBN_COMPILED_TIME_VAR = 44`
+
+use std::os::raw::c_int;
+
+// ── Struct definitions matching the C types in bn.h ──────────────────────────
+
+/// Scalar field element (Fr). 4 × u64 = 32 bytes.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct MclBnFr {
+    pub d: [u64; 4],
+}
+
+/// Base field element (Fp). 4 × u64 = 32 bytes.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct MclBnFp {
+    pub d: [u64; 4],
+}
+
+/// Quadratic extension field element (Fp2 = Fp + Fp·i).
+/// `d[0]` = real part, `d[1]` = imaginary part.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct MclBnFp2 {
+    pub d: [MclBnFp; 2],
+}
+
+/// G1 point in projective coordinates over Fp.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct MclBnG1 {
+    pub x: MclBnFp,
+    pub y: MclBnFp,
+    pub z: MclBnFp,
+}
+
+/// G2 point in projective coordinates over Fp2.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct MclBnG2 {
+    pub x: MclBnFp2,
+    pub y: MclBnFp2,
+    pub z: MclBnFp2,
+}
+
+/// Target group element (GT ⊂ Fp12). 12 × Fp = 384 bytes.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct MclBnGT {
+    pub d: [MclBnFp; 12],
+}
+
+// ── Extern "C" function declarations ─────────────────────────────────────────
+
+#[link(name = "mcl", kind = "static")]
+extern "C" {
+    // ── Global ───────────────────────────────────────────────────────────────
+    pub fn mclBn_init(curve: c_int, compiledTimeVar: c_int) -> c_int;
+    pub fn mclBn_getVersion() -> u32;
+    pub fn mclBn_pairing(z: *mut MclBnGT, x: *const MclBnG1, y: *const MclBnG2);
+    pub fn mclBn_millerLoop(z: *mut MclBnGT, x: *const MclBnG1, y: *const MclBnG2);
+    pub fn mclBn_millerLoopVec(
+        z: *mut MclBnGT,
+        x: *const MclBnG1,
+        y: *const MclBnG2,
+        n: usize,
+    );
+    pub fn mclBn_finalExp(y: *mut MclBnGT, x: *const MclBnGT);
+    pub fn mclBn_verifyOrderG1(doVerify: c_int);
+    pub fn mclBn_verifyOrderG2(doVerify: c_int);
+    pub fn mclBn_getG1ByteSize() -> c_int;
+    pub fn mclBn_getFrByteSize() -> c_int;
+    pub fn mclBn_getFpByteSize() -> c_int;
+
+    // ── Fr (scalar field) ────────────────────────────────────────────────────
+    pub fn mclBnFr_clear(x: *mut MclBnFr);
+    pub fn mclBnFr_setInt32(y: *mut MclBnFr, x: c_int);
+    pub fn mclBnFr_serialize(buf: *mut u8, maxBufSize: usize, x: *const MclBnFr) -> usize;
+    pub fn mclBnFr_deserialize(x: *mut MclBnFr, buf: *const u8, bufSize: usize) -> usize;
+    pub fn mclBnFr_setLittleEndianMod(x: *mut MclBnFr, buf: *const u8, bufSize: usize) -> c_int;
+    pub fn mclBnFr_isValid(x: *const MclBnFr) -> c_int;
+    pub fn mclBnFr_isEqual(x: *const MclBnFr, y: *const MclBnFr) -> c_int;
+    pub fn mclBnFr_isZero(x: *const MclBnFr) -> c_int;
+    pub fn mclBnFr_isOne(x: *const MclBnFr) -> c_int;
+    pub fn mclBnFr_add(z: *mut MclBnFr, x: *const MclBnFr, y: *const MclBnFr);
+    pub fn mclBnFr_sub(z: *mut MclBnFr, x: *const MclBnFr, y: *const MclBnFr);
+    pub fn mclBnFr_mul(z: *mut MclBnFr, x: *const MclBnFr, y: *const MclBnFr);
+    pub fn mclBnFr_neg(y: *mut MclBnFr, x: *const MclBnFr);
+    pub fn mclBnFr_inv(y: *mut MclBnFr, x: *const MclBnFr);
+    pub fn mclBnFr_setByCSPRNG(x: *mut MclBnFr) -> c_int;
+
+    // ── Fp (base field) ──────────────────────────────────────────────────────
+    pub fn mclBnFp_clear(x: *mut MclBnFp);
+    pub fn mclBnFp_setInt32(y: *mut MclBnFp, x: c_int);
+    pub fn mclBnFp_serialize(buf: *mut u8, maxBufSize: usize, x: *const MclBnFp) -> usize;
+    pub fn mclBnFp_deserialize(x: *mut MclBnFp, buf: *const u8, bufSize: usize) -> usize;
+    pub fn mclBnFp_isZero(x: *const MclBnFp) -> c_int;
+    pub fn mclBnFp_isValid(x: *const MclBnFp) -> c_int;
+    pub fn mclBnFp_isEqual(x: *const MclBnFp, y: *const MclBnFp) -> c_int;
+
+    // ── G1 ───────────────────────────────────────────────────────────────────
+    pub fn mclBnG1_clear(x: *mut MclBnG1);
+    pub fn mclBnG1_isValid(x: *const MclBnG1) -> c_int;
+    pub fn mclBnG1_isEqual(x: *const MclBnG1, y: *const MclBnG1) -> c_int;
+    pub fn mclBnG1_isZero(x: *const MclBnG1) -> c_int;
+    pub fn mclBnG1_isValidOrder(x: *const MclBnG1) -> c_int;
+    pub fn mclBnG1_add(z: *mut MclBnG1, x: *const MclBnG1, y: *const MclBnG1);
+    pub fn mclBnG1_sub(z: *mut MclBnG1, x: *const MclBnG1, y: *const MclBnG1);
+    pub fn mclBnG1_neg(y: *mut MclBnG1, x: *const MclBnG1);
+    pub fn mclBnG1_dbl(y: *mut MclBnG1, x: *const MclBnG1);
+    pub fn mclBnG1_mul(z: *mut MclBnG1, x: *const MclBnG1, y: *const MclBnFr);
+    pub fn mclBnG1_mulCT(z: *mut MclBnG1, x: *const MclBnG1, y: *const MclBnFr);
+    pub fn mclBnG1_normalize(y: *mut MclBnG1, x: *const MclBnG1);
+    pub fn mclBnG1_serialize(buf: *mut u8, maxBufSize: usize, x: *const MclBnG1) -> usize;
+    pub fn mclBnG1_deserialize(x: *mut MclBnG1, buf: *const u8, bufSize: usize) -> usize;
+    pub fn mclBnG1_hashAndMapTo(x: *mut MclBnG1, buf: *const u8, bufSize: usize) -> c_int;
+
+    // ── G2 ───────────────────────────────────────────────────────────────────
+    pub fn mclBnG2_clear(x: *mut MclBnG2);
+    pub fn mclBnG2_isValid(x: *const MclBnG2) -> c_int;
+    pub fn mclBnG2_isEqual(x: *const MclBnG2, y: *const MclBnG2) -> c_int;
+    pub fn mclBnG2_isZero(x: *const MclBnG2) -> c_int;
+    pub fn mclBnG2_isValidOrder(x: *const MclBnG2) -> c_int;
+    pub fn mclBnG2_add(z: *mut MclBnG2, x: *const MclBnG2, y: *const MclBnG2);
+    pub fn mclBnG2_sub(z: *mut MclBnG2, x: *const MclBnG2, y: *const MclBnG2);
+    pub fn mclBnG2_neg(y: *mut MclBnG2, x: *const MclBnG2);
+    pub fn mclBnG2_dbl(y: *mut MclBnG2, x: *const MclBnG2);
+    pub fn mclBnG2_mul(z: *mut MclBnG2, x: *const MclBnG2, y: *const MclBnFr);
+    pub fn mclBnG2_normalize(y: *mut MclBnG2, x: *const MclBnG2);
+    pub fn mclBnG2_serialize(buf: *mut u8, maxBufSize: usize, x: *const MclBnG2) -> usize;
+    pub fn mclBnG2_deserialize(x: *mut MclBnG2, buf: *const u8, bufSize: usize) -> usize;
+    pub fn mclBnG2_hashAndMapTo(x: *mut MclBnG2, buf: *const u8, bufSize: usize) -> c_int;
+
+    // ── GT ───────────────────────────────────────────────────────────────────
+    pub fn mclBnGT_clear(x: *mut MclBnGT);
+    pub fn mclBnGT_setInt32(y: *mut MclBnGT, x: c_int);
+    pub fn mclBnGT_isEqual(x: *const MclBnGT, y: *const MclBnGT) -> c_int;
+    pub fn mclBnGT_isOne(x: *const MclBnGT) -> c_int;
+    pub fn mclBnGT_isZero(x: *const MclBnGT) -> c_int;
+    pub fn mclBnGT_mul(z: *mut MclBnGT, x: *const MclBnGT, y: *const MclBnGT);
+    pub fn mclBnGT_pow(z: *mut MclBnGT, x: *const MclBnGT, y: *const MclBnFr);
+    pub fn mclBnGT_inv(y: *mut MclBnGT, x: *const MclBnGT);
+    pub fn mclBnGT_serialize(buf: *mut u8, maxBufSize: usize, x: *const MclBnGT) -> usize;
+    pub fn mclBnGT_deserialize(x: *mut MclBnGT, buf: *const u8, bufSize: usize) -> usize;
+}

--- a/ffi/rust/src/lib.rs
+++ b/ffi/rust/src/lib.rs
@@ -1,0 +1,27 @@
+//! Rust FFI bindings for [herumi/mcl](https://github.com/herumi/mcl) BN254 curve operations.
+//!
+//! Provides safe wrappers for G1/G2 point arithmetic and optimal ate pairings
+//! on the BN254 curve, with serialization matching Ethereum's precompile format.
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use mcl_bn254::{init, G1, G2, Fr, pairing};
+//!
+//! // Must initialize before use
+//! assert!(init());
+//!
+//! // Parse points from Ethereum-format bytes
+//! let g1 = G1::from_eth(&[0u8; 64]).unwrap(); // point at infinity
+//! let g2 = G2::from_eth(&[0u8; 128]).unwrap();
+//!
+//! // Compute pairing
+//! let gt = pairing(&g1, &g2);
+//! ```
+
+pub mod bn254;
+pub mod ffi;
+
+pub use bn254::{
+    final_exp, init, miller_loop, multi_miller_loop, pairing, pairing_check, Fp, Fr, G1, G2, GT,
+};

--- a/ffi/rust/tests/bn254_test.rs
+++ b/ffi/rust/tests/bn254_test.rs
@@ -1,0 +1,384 @@
+//! Integration tests using Ethereum BN254 precompile test vectors.
+
+use mcl_bn254::{init, pairing_check, Fr, G1, G2};
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect()
+}
+
+fn hex_to_array<const N: usize>(s: &str) -> [u8; N] {
+    let bytes = hex_to_bytes(s);
+    assert_eq!(bytes.len(), N, "expected {} bytes, got {}", N, bytes.len());
+    let mut arr = [0u8; N];
+    arr.copy_from_slice(&bytes);
+    arr
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn setup() {
+    assert!(init(), "mcl BN254 initialization failed");
+}
+
+// ── ecAdd tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_g1_add_valid_points() {
+    setup();
+
+    let p1 = G1::from_eth(&hex_to_array::<64>(
+        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9\
+         063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+    ))
+    .unwrap();
+
+    let p2 = G1::from_eth(&hex_to_array::<64>(
+        "07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed\
+         06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
+    ))
+    .unwrap();
+
+    let result = p1.add(&p2);
+    let result_bytes = result.to_eth();
+
+    let expected = hex_to_bytes(
+        "2243525c5efd4b9c3d3c45ac0ca3fe4dd85e830a4ce6b65fa1eeaee202839703\
+         301d1d33be6da8e509df21cc35964723180eed7532537db9ae5e7d48f195c915",
+    );
+
+    assert_eq!(
+        bytes_to_hex(&result_bytes),
+        bytes_to_hex(&expected),
+        "G1 add result mismatch"
+    );
+}
+
+#[test]
+fn test_g1_add_identity() {
+    setup();
+
+    let zero = G1::from_eth(&[0u8; 64]).unwrap();
+    let result = zero.add(&zero);
+    assert!(result.is_zero(), "0 + 0 should be point at infinity");
+    assert_eq!(result.to_eth(), [0u8; 64]);
+}
+
+#[test]
+fn test_g1_add_with_identity() {
+    setup();
+
+    let p = G1::from_eth(&hex_to_array::<64>(
+        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9\
+         063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+    ))
+    .unwrap();
+
+    let zero = G1::zero();
+    let result = p.add(&zero);
+    assert_eq!(
+        bytes_to_hex(&result.to_eth()),
+        bytes_to_hex(&p.to_eth()),
+        "P + 0 should equal P"
+    );
+}
+
+#[test]
+fn test_g1_add_invalid_point() {
+    setup();
+
+    let result = G1::from_eth(&hex_to_array::<64>(
+        "1111111111111111111111111111111111111111111111111111111111111111\
+         1111111111111111111111111111111111111111111111111111111111111111",
+    ));
+    assert!(result.is_none(), "invalid point should fail");
+}
+
+// ── ecMul tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_g1_scalar_mul() {
+    setup();
+
+    let p = G1::from_eth(&hex_to_array::<64>(
+        "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7\
+         21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+    ))
+    .unwrap();
+
+    let scalar = Fr::from_be_bytes(&hex_to_array::<32>(
+        "00000000000000000000000000000000000000000000000011138ce750fa15c2",
+    ));
+
+    let result = p.mul(&scalar);
+    let result_bytes = result.to_eth();
+
+    let expected = hex_to_bytes(
+        "070a8d6a982153cae4be29d434e8faef8a47b274a053f5a4ee2a6c9c13c31e5c\
+         031b8ce914eba3a9ffb989f9cdd5b0f01943074bf4f0f315690ec3cec6981afc",
+    );
+
+    assert_eq!(
+        bytes_to_hex(&result_bytes),
+        bytes_to_hex(&expected),
+        "G1 scalar mul result mismatch"
+    );
+}
+
+#[test]
+fn test_g1_mul_by_zero() {
+    setup();
+
+    let p = G1::from_eth(&hex_to_array::<64>(
+        "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7\
+         21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+    ))
+    .unwrap();
+
+    let zero_scalar = Fr::zero();
+    let result = p.mul(&zero_scalar);
+    assert!(result.is_zero(), "P * 0 should be point at infinity");
+}
+
+#[test]
+fn test_g1_mul_identity_scalar() {
+    setup();
+
+    let p = G1::from_eth(&hex_to_array::<64>(
+        "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7\
+         21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+    ))
+    .unwrap();
+
+    let one_scalar = Fr::one();
+    let result = p.mul(&one_scalar);
+    assert_eq!(
+        bytes_to_hex(&result.to_eth()),
+        bytes_to_hex(&p.to_eth()),
+        "P * 1 should equal P"
+    );
+}
+
+#[test]
+fn test_g1_mul_invalid_point() {
+    setup();
+
+    let result = G1::from_eth(&hex_to_array::<64>(
+        "1111111111111111111111111111111111111111111111111111111111111111\
+         1111111111111111111111111111111111111111111111111111111111111111",
+    ));
+    assert!(result.is_none(), "invalid point should fail");
+}
+
+// ── ecPairing tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_pairing_two_pairs() {
+    setup();
+
+    // Two pairs that satisfy e(P1,Q1) * e(P2,Q2) = 1
+    let input = hex_to_bytes(
+        "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59\
+         3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41\
+         209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7\
+         04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678\
+         2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d\
+         120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550\
+         111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c\
+         2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411\
+         198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2\
+         1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed\
+         090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b\
+         12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+    );
+
+    assert_eq!(input.len(), 384, "pairing input should be 384 bytes");
+
+    let g1_a = G1::from_eth(input[0..64].try_into().unwrap()).unwrap();
+    let g2_a = G2::from_eth(input[64..192].try_into().unwrap()).unwrap();
+    let g1_b = G1::from_eth(input[192..256].try_into().unwrap()).unwrap();
+    let g2_b = G2::from_eth(input[256..384].try_into().unwrap()).unwrap();
+
+    assert!(
+        pairing_check(&[g1_a, g1_b], &[g2_a, g2_b]),
+        "pairing check should return true"
+    );
+}
+
+#[test]
+fn test_pairing_empty_input() {
+    setup();
+
+    // Empty pairing = product of zero pairings = 1 in GT
+    assert!(
+        pairing_check(&[], &[]),
+        "empty pairing should return true"
+    );
+}
+
+#[test]
+fn test_pairing_g1_infinity() {
+    setup();
+
+    // G1 = (0,0) (infinity), valid G2 → pairing should return true
+    let g1 = G1::from_eth(&[0u8; 64]).unwrap();
+    let g2_bytes = hex_to_array::<128>(
+        "209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7\
+         04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678\
+         2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d\
+         120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550",
+    );
+    let g2 = G2::from_eth(&g2_bytes).unwrap();
+
+    assert!(
+        pairing_check(&[g1], &[g2]),
+        "pairing with G1 infinity should return true"
+    );
+}
+
+#[test]
+fn test_pairing_g2_infinity() {
+    setup();
+
+    // valid G1, G2 = (0,0,0,0) (infinity) → pairing should return true
+    let g1_bytes = hex_to_array::<64>(
+        "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59\
+         3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41",
+    );
+    let g1 = G1::from_eth(&g1_bytes).unwrap();
+    let g2 = G2::from_eth(&[0u8; 128]).unwrap();
+
+    assert!(
+        pairing_check(&[g1], &[g2]),
+        "pairing with G2 infinity should return true"
+    );
+}
+
+// ── Fr / operator tests ──────────────────────────────────────────────────────
+
+#[test]
+fn test_fr_arithmetic() {
+    setup();
+
+    let a = Fr::one();
+    let b = Fr::one();
+
+    let sum = a + b;
+    assert!(!sum.is_zero());
+    assert!(!sum.is_one());
+
+    let diff = sum - a;
+    assert!(diff.is_one(), "2 - 1 should be 1");
+
+    let product = a * b;
+    assert!(product.is_one(), "1 * 1 should be 1");
+
+    let neg_a = -a;
+    let should_be_zero = a + neg_a;
+    assert!(should_be_zero.is_zero(), "a + (-a) should be 0");
+}
+
+#[test]
+fn test_fr_serialization_roundtrip() {
+    setup();
+
+    let bytes = hex_to_array::<32>(
+        "00000000000000000000000000000000000000000000000011138ce750fa15c2",
+    );
+    let fr = Fr::from_be_bytes(&bytes);
+    let roundtrip = fr.to_be_bytes();
+    assert_eq!(bytes_to_hex(&roundtrip), bytes_to_hex(&bytes));
+}
+
+// ── G1 operator overload tests ───────────────────────────────────────────────
+
+#[test]
+fn test_g1_operator_add() {
+    setup();
+
+    let p1 = G1::from_eth(&hex_to_array::<64>(
+        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9\
+         063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+    ))
+    .unwrap();
+
+    let p2 = G1::from_eth(&hex_to_array::<64>(
+        "07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed\
+         06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
+    ))
+    .unwrap();
+
+    // Using operator overload
+    let result_op = p1 + p2;
+    // Using method
+    let result_method = p1.add(&p2);
+
+    assert!(result_op == result_method, "operator + should match .add()");
+}
+
+#[test]
+fn test_g1_scalar_mul_operator() {
+    setup();
+
+    let p = G1::from_eth(&hex_to_array::<64>(
+        "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7\
+         21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+    ))
+    .unwrap();
+
+    let scalar = Fr::from_be_bytes(&hex_to_array::<32>(
+        "00000000000000000000000000000000000000000000000011138ce750fa15c2",
+    ));
+
+    let result_op = p * scalar;
+    let result_method = p.mul(&scalar);
+
+    assert!(
+        result_op == result_method,
+        "operator * should match .mul()"
+    );
+}
+
+// ── G1 serialization roundtrip ───────────────────────────────────────────────
+
+#[test]
+fn test_g1_serialization_roundtrip() {
+    setup();
+
+    let original_bytes = hex_to_array::<64>(
+        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9\
+         063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+    );
+
+    let p = G1::from_eth(&original_bytes).unwrap();
+    let roundtrip = p.to_eth();
+    assert_eq!(
+        bytes_to_hex(&roundtrip),
+        bytes_to_hex(&original_bytes),
+        "G1 serialization roundtrip failed"
+    );
+}
+
+#[test]
+fn test_g2_serialization_roundtrip() {
+    setup();
+
+    let original_bytes = hex_to_array::<128>(
+        "209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7\
+         04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678\
+         2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d\
+         120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550",
+    );
+
+    let p = G2::from_eth(&original_bytes).unwrap();
+    let roundtrip = p.to_eth();
+    assert_eq!(
+        bytes_to_hex(&roundtrip),
+        bytes_to_hex(&original_bytes),
+        "G2 serialization roundtrip failed"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `ffi/rust/` crate (`mcl-bn254`) providing safe Rust FFI bindings for BN254 (alt_bn128) curve operations
- Follows the existing pattern of language-specific bindings in `ffi/` (Go, Java, Python, C#, JS)
- Focused on operations needed by Ethereum precompiles (EIP-196/197): G1 add, G1 scalar mul, pairing check

## What's included

**`ffi/rust/src/ffi.rs`** — Raw `extern "C"` bindings to `bn.h` for BN254 (MCL_FP_BIT=256, MCL_FR_BIT=256)

**`ffi/rust/src/bn254.rs`** — Safe Rust wrappers:
- `Fr`, `Fp`, `G1`, `G2`, `GT` types with arithmetic operations
- Ethereum-format serialization (big-endian, matching EIP-196/197)
- `pairing()`, `multi_miller_loop()`, `final_exp()`, `pairing_check()`
- Operator overloads (`Add`, `Sub`, `Mul`, `Neg`) for ergonomic usage

**`ffi/rust/build.rs`** — CMake-based build that compiles mcl as a static library with `MCL_STANDALONE=ON`

**`ffi/rust/tests/bn254_test.rs`** — 18 integration tests using Ethereum precompile test vectors (ecAdd, ecMul, ecPairing)

**`ffi/rust/examples/pairing.rs`** — Example demonstrating all core operations

## Test plan

- [x] `cargo build` — compiles mcl C++ library and links statically
- [x] `cargo test` — 18 tests pass using Ethereum precompile test vectors
- [x] `cargo run --example pairing` — runs pairing example successfully
- [ ] Test on Linux x86_64
- [ ] Test on Linux aarch64